### PR TITLE
chore: lock gh actions on sha instead of tag

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -7,6 +7,7 @@ on:
       - synchronize
     branches-ignore:
       - 'release-please--branches--*'
+
 jobs:
   main:
     name: Validate PR title

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,5 +1,4 @@
 name: "Lint PR title"
-
 on:
   pull_request_target:
     types:
@@ -8,13 +7,12 @@ on:
       - synchronize
     branches-ignore:
       - 'release-please--branches--*'
-
 jobs:
   main:
     name: Validate PR title
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5
+      - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # ratchet:amannn/action-semantic-pull-request@v5
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -1,6 +1,4 @@
----
 name: PR opened
-
 on:
   pull_request_target:
     # GITHUB_TOKEN is readonly and the action will fail for Dependabot
@@ -8,14 +6,13 @@ on:
       - 'dependabot/**'
     types:
       - opened
-
 jobs:
   add-welcome-message:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/github-script@v6
+      - uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
         with:
           script: |
             // adds a comment to the PR (there is the issue API only which works work PRs too)

--- a/.github/workflows/pr-opened.yml
+++ b/.github/workflows/pr-opened.yml
@@ -6,6 +6,7 @@ on:
       - 'dependabot/**'
     types:
       - opened
+
 jobs:
   add-welcome-message:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+      
 jobs:
   release:
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,26 +1,23 @@
 name: Release
-
 on:
   push:
     branches:
       - main
-
 jobs:
   release:
     runs-on: ubuntu-latest
     steps:
       - name: Get app installation token
-        uses: npalm/action-app-token@v1.1.0
+        uses: npalm/action-app-token@dd4bb16d91ced5659bc618705c96b822c5a42136 # ratchet:npalm/action-app-token@v1.1.0
         id: token
         with:
           appId: ${{ secrets.APP_ID }}
           appPrivateKeyBase64: ${{ secrets.APP_PRIVATE_KEY_BASE64 }}
           appInstallationType: repo
           appInstallationValue: ${{ github.repository }}
-
       # bootstrap-sha and release-as needs to be removed after first release
       - name: Release
-        uses: google-github-actions/release-please-action@v3
+        uses: google-github-actions/release-please-action@d3c71f9a0a55385580de793de58da057b3560862 # ratchet:google-github-actions/release-please-action@v3
         with:
           release-type: terraform-module
           token: ${{ steps.token.outputs.token }}

--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -3,6 +3,7 @@ on:
   repository_dispatch:
     types:
       - help-command
+
 jobs:
   help-command:
     name: "ChatOps: /help"

--- a/.github/workflows/slash_ops_commands.yml
+++ b/.github/workflows/slash_ops_commands.yml
@@ -1,11 +1,8 @@
----
 name: Execute ChatOps command
-
 on:
   repository_dispatch:
-    types: 
+    types:
       - help-command
-
 jobs:
   help-command:
     name: "ChatOps: /help"
@@ -16,9 +13,8 @@ jobs:
         run: |
           maintainer=$(cat CODEOWNERS | grep -oE "@[a-zA-Z0-9_-]+" | shuf -n 1)
           echo "maintainer=$maintainer" >> "$GITHUB_OUTPUT"
-
       - name: Create comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # ratchet:actions/github-script@v6
         with:
           script: |
             // adds a comment to the PR (there is the issue API, which works work PRs too)

--- a/.github/workflows/slash_ops_comment_dispatch.yml
+++ b/.github/workflows/slash_ops_comment_dispatch.yml
@@ -1,17 +1,14 @@
----
 name: PR commented
-
 on:
   issue_comment:
     types:
       - created
-
 jobs:
   slash-command-dispatch:
     runs-on: ubuntu-latest
     steps:
       - name: Slash Command Dispatch
-        uses: peter-evans/slash-command-dispatch@v3
+        uses: peter-evans/slash-command-dispatch@a28ee6cd74d5200f99e247ebc7b365c03ae0ef3c # ratchet:peter-evans/slash-command-dispatch@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-type: pull-request

--- a/.github/workflows/slash_ops_comment_dispatch.yml
+++ b/.github/workflows/slash_ops_comment_dispatch.yml
@@ -3,6 +3,7 @@ on:
   issue_comment:
     types:
       - created
+
 jobs:
   slash-command-dispatch:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,6 +2,7 @@ name: 'Close stale issues and PRs'
 on:
   schedule:
     - cron: '25 2 * * *'
+
 jobs:
   stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,14 +1,12 @@
 name: 'Close stale issues and PRs'
-
 on:
   schedule:
     - cron: '25 2 * * *'
-
 jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v7
+      - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # ratchet:actions/stale@v7
         with:
           stale-issue-message: 'This issue is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days.'
           stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 15 days.'

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -1,22 +1,18 @@
 name: Update docs
-
 on:
   push:
     branches:
       - release-please--branches--main
-
 jobs:
   docs:
     # update docs after merge back to develop
     name: Auto update terraform docs
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout branch
-        uses: actions/checkout@v3
-
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # ratchet:actions/checkout@v3
       - name: Generate TF docs
-        uses: terraform-docs/gh-actions@v1.0.0
+        uses: terraform-docs/gh-actions@f6d59f89a280fa0a3febf55ef68f146784b20ba0 # ratchet:terraform-docs/gh-actions@v1.0.0
         with:
           find-dir: .
           git-commit-message: "docs: auto update terraform docs"

--- a/.github/workflows/update_docs.yml
+++ b/.github/workflows/update_docs.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - release-please--branches--main
+
 jobs:
   docs:
     # update docs after merge back to develop


### PR DESCRIPTION
## Description

A good practice in supply chain security is to have immutable builds. Currently GH tags for actions are mutable, even when a specific tag like x.y.z is used. Therefore, this PR locks the actions on the SHA. Dependabot can update the actions based on SHA, including the comments poitning to the underlying version.

## Migrations required

NO

## Verification

n/a