### PR TITLE
fix: null condition for enable_manage_gitlab_token in release v6.1.0

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -508,8 +508,6 @@ resource "aws_iam_policy" "ssm" {
 }
 
 resource "aws_iam_role_policy_attachment" "ssm" {
-  count = var.enable_manage_gitlab_token ? 1 : 0
-
   role       = var.create_runner_iam_role ? aws_iam_role.instance[0].name : local.aws_iam_role_instance_name
   policy_arn = aws_iam_policy.ssm.arn
 }


### PR DESCRIPTION
## Description

Pull request #510 missed one last usage of `var.enable_manage_gitlab_token` as noted by @npalm in a resolved review comment.

## Migrations required

No, this requires the same level of migration as #510.

## Verification

Verified in my production runner setup which is similar to the default example with some minor tweaks.

v6.1.0 fails with this error:

```
Error: Null condition

  on main.tf line 511, in resource "aws_iam_role_policy_attachment" "ssm":
 511:   count = var.enable_manage_gitlab_token ? 1 : 0
    ├────────────────
    │ var.enable_manage_gitlab_token is null
The condition value is null. Conditions must either be true or false.
```

This change fixes this resulting in a valid plan.