### PR TITLE
ci: fix PR linter (single commit and permissions)

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,6 +1,6 @@
 name: "Lint PR title"
 on:
-  pull_request_target:
+  pull_request:
     types:
       - opened
       - edited

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -63,7 +63,7 @@ jobs:
           # will suggest using that commit message instead of the PR title for the
           # merge commit, and it's easy to commit this by mistake. Enable this option
           # to also validate the commit message for one commit PRs.
-          validateSingleCommit: true
+          validateSingleCommit: false
           # Related to `validateSingleCommit` you can opt-in to validate that the PR
           # title matches a single commit to avoid confusion.
           validateSingleCommitMatchesPrTitle: false

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -1,6 +1,6 @@
 name: "Lint PR title"
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited


### PR DESCRIPTION
## Description

This PR allows the PR linter to succeed if there is only one commit as we switched to a default commit message of "PR title and PR body". So nothing is calculated by GitHub at time of merging. There will never be a problem with overwriting the commit message accidentally as it is fixed now.

It avoids this error message from the linter: `Error: Pull request has only one commit and it's not semantic; this may lead to a non-semantic commit in the base branch (see https://github.community/t/how-to-change-the-default-squash-merge-commit-message/1155). Amend the commit message to match the pull request title, or add another commit.`

In addition we run the check on the pull request instead of the pull request target. This way we get an elevated `GITHUB_TOKEN` and can access the PR.

## Migrations required

No

## Verification

None
