### PR TITLE
ci: avoid API rate limiting setting up TfLint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,8 @@ jobs:
 
       - uses: terraform-linters/setup-tflint@v2
         name: Setup TFLint
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tflint_version: latest
 


### PR DESCRIPTION
## Description

Adds the `GITHUB_TOKEN` to the TfLint action to avoid hitting the Github API rate limiting as explained here: https://github.com/terraform-linters/tflint/blob/master/docs/user-guide/plugins.md#avoiding-rate-limiting

I saw many pipelines failing with the rate limiting error.

## Migrations required

No.

## Verification

Check that the TfLint job still runs in this PR.
