### PR TITLE
ci: do not check the links in `CHANGELOG.md`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,6 +84,8 @@ jobs:
           TERRAFORM_TERRAFORM_FMT_DISABLE_ERRORS: false
           # it's an auto-generated file
           MARKDOWN_MARKDOWNLINT_FILTER_REGEX_EXCLUDE: (CHANGELOG.md)
+          # it's an auto-generated file
+          MARKDOWN_MARKDOWN_LINK_CHECK_FILTER_REGEX_EXCLUDE: (CHANGELOG.md)
           PAT: ${{ secrets.GITHUB_TOKEN }}
           # automatically commit fixes to the feature branch
           APPLY_FIXES: all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,3 @@
-x
 # Changelog
 
 ## [6.2.0](https://github.com/cattle-ops/terraform-aws-gitlab-runner/compare/6.1.2...6.2.0) (2023-03-22)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+x
 # Changelog
 
 ## [6.2.0](https://github.com/cattle-ops/terraform-aws-gitlab-runner/compare/6.1.2...6.2.0) (2023-03-22)


### PR DESCRIPTION
## Description

`CHANGELOG.md` is an auto-generated file. It makes no sense to check whether the links are correct or not as we shouldn't change this file.

## Migrations required

No

## Verification

- [x] Ensure the `CHANGELOG.md` is no longer checked
