### PR TITLE
ci: fix Megalinter version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
         id: ml
         # You can override MegaLinter flavor used to have faster performances
         # More info at https://megalinter.io/flavors/
-        uses: oxsecurity/megalinter@v6
+        uses: oxsecurity/megalinter@v6.21.0
         env:
           # All available variables are described in documentation
           # https://megalinter.io/configuration/

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -56,7 +56,7 @@ resource "aws_s3_bucket_versioning" "build_cache_versioning" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
-  # checkov:skip=CKV2_AWS_62:False positive. Can be removed when https://github.com/bridgecrewio/checkov/issues/4733 is fixed.
+  # checkov:skip=CKV_AWS_300:False positive. Can be removed when https://github.com/bridgecrewio/checkov/issues/4733 is fixed.
   bucket = aws_s3_bucket.build_cache.id
 
   rule {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -59,7 +59,7 @@ resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
   bucket = aws_s3_bucket.build_cache.id
 
   rule {
-    id     = "Abort incomplete multipart uploads"
+    id     = "AbortIncompleteMultipartUploads"
     status = "Enabled"
 
     abort_incomplete_multipart_upload {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -56,6 +56,7 @@ resource "aws_s3_bucket_versioning" "build_cache_versioning" {
 }
 
 resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
+  # checkov:skip=CKV2_AWS_62:False positive. Can be removed when https://github.com/bridgecrewio/checkov/issues/4733 is fixed.
   bucket = aws_s3_bucket.build_cache.id
 
   rule {

--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -30,6 +30,7 @@ resource "random_string" "s3_suffix" {
 resource "aws_s3_bucket" "build_cache" {
   # checkov:skip=CKV_AWS_21:Versioning can be decided by user
   # checkov:skip=CKV_AWS_144:It's a cache only. Replication not needed.
+  # checkov:skip=CKV2_AWS_62:It's a simple cache. We don't want to notify anyone.
   bucket = local.cache_bucket_name
 
   tags = local.tags
@@ -56,6 +57,15 @@ resource "aws_s3_bucket_versioning" "build_cache_versioning" {
 
 resource "aws_s3_bucket_lifecycle_configuration" "build_cache_versioning" {
   bucket = aws_s3_bucket.build_cache.id
+
+  rule {
+    id     = "Abort incomplete multipart uploads"
+    status = "Enabled"
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 1
+    }
+  }
 
   rule {
     id     = "clear"


### PR DESCRIPTION
## Description

Currently we are using `v6`. But this introduces new checks on the fly which is cumbersome. This PR fixes the version used.

## Migrations required

No

## Verification

- [x] Megalinter is still running
