### PR TITLE
fix: remove explicit aws_s3_bucket_acl

### DIFF
--- a/modules/cache/main.tf
+++ b/modules/cache/main.tf
@@ -38,12 +38,6 @@ resource "aws_s3_bucket" "build_cache" {
   force_destroy = true
 }
 
-resource "aws_s3_bucket_acl" "build_cache_acl" {
-  bucket = aws_s3_bucket.build_cache.id
-
-  acl = "private"
-}
-
 resource "aws_s3_bucket_versioning" "build_cache_versioning" {
   bucket = aws_s3_bucket.build_cache.id
 


### PR DESCRIPTION
This resolves an issue related to the April 2023 S3 API changes. More info can be found here: https://github.com/hashicorp/terraform-provider-aws/issues/28353

Closes #814

## Description

Remove the explicit private ACL that leads to an error during the apply phase as with the new security defaults, it should no longer be needed. I'm not 100% on the implications of removing this resource for existing deployments, so if that's a concern we can go the route of adding the explicit `aws_s3_bucket_ownership_controls` resource as per the related issue.

## Migrations required

NO

## Verification

- Solves the issue in #814 using the recommendations from: https://github.com/hashicorp/terraform-provider-aws/issues/28353
- manually tested and checked that the cache is still accessible

