### PR TITLE
fix: allow s3 cache access for the "docker" runner executor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -545,7 +545,7 @@ resource "aws_iam_role_policy_attachment" "docker_machine_cache_instance" {
   /* If the S3 cache adapter is configured to use an IAM instance profile, the
      adapter uses the profile attached to the GitLab Runner machine. So do not
      use aws_iam_role.docker_machine.name here! See https://docs.gitlab.com/runner/configuration/advanced-configuration.html */
-  count = var.runners_executor == "docker+machine" ? (var.cache_bucket["create"] || lookup(var.cache_bucket, "policy", "") != "" ? 1 : 0) : 0
+  count = var.cache_bucket["create"] || lookup(var.cache_bucket, "policy", "") != "" ? 1 : 0
 
   role       = var.create_runner_iam_role ? aws_iam_role.instance[0].name : local.aws_iam_role_instance_name
   policy_arn = local.bucket_policy


### PR DESCRIPTION
Closes #816

## Description

This fixes the "docker" runner executor not having access to the S3 bucket by always attaching the bucket policy if it exists.

## Migrations required

NO

## Verification

Ran changes locally and observed the issue was resolved with this change.
