### PR TITLE
chore: make the `runners_user_data` a sensitive output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -55,5 +55,5 @@ output "runner_launch_template_name" {
 
 output "runner_user_data" {
   description = "The user data of the Gitlab Runner Agent's launch template."
-  value       = local.template_user_data
+  value       = nonsensitive(local.template_user_data)
 }


### PR DESCRIPTION
## Description

Some credentials are leaking through the output `runners_user_data`. We don't want to see these in our pipeline logs.

## Migrations required

No

## Verification

No verification done.
