### PR TITLE
feat: add option to read Gitlab Runner Registration token from SSM

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,8 @@ gitlab_runner_registration_config = {
   access_level       = "<not_protected OR ref_protected>"
 }
 ```
+The registration token can also be read in via SSM parameter store. If no registration token is passed in, the module
+will look up the token in the SSM parameter store at the location specified by `secure_parameter_store_gitlab_runner_registration_token_name`.
 
 For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will lookup the
 required values via the parameter store. If the value is `null` a new runner will be registered and a new token created/stored.

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ gitlab_runner_registration_config = {
   access_level       = "<not_protected OR ref_protected>"
 }
 ```
+
 The registration token can also be read in via SSM parameter store. If no registration token is passed in, the module
 will look up the token in the SSM parameter store at the location specified by `secure_parameter_store_gitlab_runner_registration_token_name`.
 
@@ -382,12 +383,18 @@ module "runner" {
 
 ### Scenario: Use of Spot Fleet
 
-Since spot instances can be taken over by AWS depending on the instance type and AZ you are using, you may want multiple instances types in multiple AZs. This is where spot fleets come in, when there is no capacity on one instance type and one AZ, AWS will take the next instance type and so on. This update has been possible since the [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) of docker-machine supports spot fleets.
+Since spot instances can be taken over by AWS depending on the instance type and AZ you are using, you may want multiple instances
+types in multiple AZs. This is where spot fleets come in, when there is no capacity on one instance type and one AZ, AWS will take
+the next instance type and so on. This update has been possible since the [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2)
+of docker-machine supports spot fleets.
 
-We have seen that the [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) of docker-machine this module is using consume more RAM using spot fleets.
-For comparison, if you launch 50 machines in the same time, it consumes ~1.2GB of RAM. In our case, we had to change the `instance_type` of the runner from `t3.micro` to `t3.small`.
+We have seen that the [fork](https://gitlab.com/cki-project/docker-machine/-/tree/v0.16.2-gitlab.19-cki.2) of docker-machine this
+module is using consume more RAM using spot fleets.
+For comparison, if you launch 50 machines in the same time, it consumes ~1.2GB of RAM. In our case, we had to change the
+`instance_type` of the runner from `t3.micro` to `t3.small`.
 
 #### Configuration example
+
 ```hcl
 module "runner" {
   # https://registry.terraform.io/modules/npalm/gitlab-runner/aws/

--- a/locals.tf
+++ b/locals.tf
@@ -55,10 +55,12 @@ locals {
   # Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
 
-  # Define key for runner and registration token for SSM
-  secure_parameter_store_registration_token_key = "${var.environment}-${var.secure_parameter_store_registration_token_key}"
-  secure_parameter_store_runner_token_key       = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
-  secure_parameter_store_runner_sentry_dsn      = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
+  #
+  secure_parameter_store_gitlab_runner_registration_token_name = var.secure_parameter_store_gitlab_runner_registration_token_name
+
+  # Define key for runner token for SSM
+  secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
+  secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
 
   # Custom names for runner agent instance, security groups, and IAM objects
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]

--- a/locals.tf
+++ b/locals.tf
@@ -55,9 +55,10 @@ locals {
   # Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
 
-  # Define key for runner token for SSM
-  secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
-  secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
+  # Define key for runner and registration token for SSM
+  secure_parameter_store_registration_token_key = "${var.environment}-${var.secure_parameter_store_registration_token_key}"
+  secure_parameter_store_runner_token_key       = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
+  secure_parameter_store_runner_sentry_dsn      = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"
 
   # Custom names for runner agent instance, security groups, and IAM objects
   name_runner_agent_instance = var.overrides["name_runner_agent_instance"] == "" ? local.tags["Name"] : var.overrides["name_runner_agent_instance"]

--- a/locals.tf
+++ b/locals.tf
@@ -55,9 +55,6 @@ locals {
   # Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
 
-  # Define name for registration token in SSM
-  secure_parameter_store_gitlab_runner_registration_token_name = var.secure_parameter_store_gitlab_runner_registration_token_name
-
   # Define key for runner token for SSM
   secure_parameter_store_runner_token_key  = "${var.environment}-${var.secure_parameter_store_runner_token_key}"
   secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.secure_parameter_store_runner_sentry_dsn}"

--- a/locals.tf
+++ b/locals.tf
@@ -55,7 +55,7 @@ locals {
   # Ensure max builds is optional
   runners_max_builds_string = var.runners_max_builds == 0 ? "" : format("MaxBuilds = %d", var.runners_max_builds)
 
-  #
+  # Define name for registration token in SSM
   secure_parameter_store_gitlab_runner_registration_token_name = var.secure_parameter_store_gitlab_runner_registration_token_name
 
   # Define key for runner token for SSM

--- a/main.tf
+++ b/main.tf
@@ -68,7 +68,7 @@ locals {
       runners_token                                                = var.runners_token
       secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn
-      secure_parameter_store_gitlab_runner_registration_token_name = local.secure_parameter_store_gitlab_runner_registration_token_name
+      secure_parameter_store_gitlab_runner_registration_token_name = var.secure_parameter_store_gitlab_runner_registration_token_name
       secure_parameter_store_region                                = var.aws_region
       gitlab_runner_registration_token                             = lookup(var.gitlab_runner_registration_config, "registration_token", "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
       gitlab_runner_description                                    = var.gitlab_runner_registration_config["description"]

--- a/main.tf
+++ b/main.tf
@@ -69,7 +69,7 @@ locals {
       secure_parameter_store_runner_token_key      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn     = local.secure_parameter_store_runner_sentry_dsn
       secure_parameter_store_region                = var.aws_region
-      gitlab_runner_registration_token             = var.gitlab_runner_registration_config["registration_token"]
+      gitlab_runner_registration_token             = lookup(var.gitlab_runner_registration_config, "registration_token", "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
       gitlab_runner_description                    = var.gitlab_runner_registration_config["description"]
       gitlab_runner_tag_list                       = var.gitlab_runner_registration_config["tag_list"]
       gitlab_runner_locked_to_project              = var.gitlab_runner_registration_config["locked_to_project"]

--- a/main.tf
+++ b/main.tf
@@ -53,33 +53,34 @@ locals {
 
   template_gitlab_runner = templatefile("${path.module}/template/gitlab-runner.tftpl",
     {
-      gitlab_runner_version                        = var.gitlab_runner_version
-      docker_machine_version                       = var.docker_machine_version
-      docker_machine_download_url                  = var.docker_machine_download_url
-      runners_config                               = local.template_runner_config
-      runners_userdata                             = var.runners_userdata
-      runners_executor                             = var.runners_executor
-      runners_install_amazon_ecr_credential_helper = var.runners_install_amazon_ecr_credential_helper
-      curl_cacert                                  = length(var.runners_gitlab_certificate) > 0 ? "--cacert /etc/gitlab-runner/certs/gitlab.crt" : ""
-      pre_install_certificates                     = local.pre_install_certificates
-      pre_install                                  = var.userdata_pre_install
-      post_install                                 = var.userdata_post_install
-      runners_gitlab_url                           = var.runners_gitlab_url
-      runners_token                                = var.runners_token
-      secure_parameter_store_runner_token_key      = local.secure_parameter_store_runner_token_key
-      secure_parameter_store_runner_sentry_dsn     = local.secure_parameter_store_runner_sentry_dsn
-      secure_parameter_store_region                = var.aws_region
-      gitlab_runner_registration_token             = lookup(var.gitlab_runner_registration_config, "registration_token", "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
-      gitlab_runner_description                    = var.gitlab_runner_registration_config["description"]
-      gitlab_runner_tag_list                       = var.gitlab_runner_registration_config["tag_list"]
-      gitlab_runner_locked_to_project              = var.gitlab_runner_registration_config["locked_to_project"]
-      gitlab_runner_run_untagged                   = var.gitlab_runner_registration_config["run_untagged"]
-      gitlab_runner_maximum_timeout                = var.gitlab_runner_registration_config["maximum_timeout"]
-      gitlab_runner_access_level                   = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
-      sentry_dsn                                   = var.sentry_dsn
-      public_key                                   = var.use_fleet == true ? tls_private_key.fleet[0].public_key_openssh : ""
-      use_fleet                                    = var.use_fleet
-      private_key                                  = var.use_fleet == true ? tls_private_key.fleet[0].private_key_pem : ""
+      gitlab_runner_version                                        = var.gitlab_runner_version
+      docker_machine_version                                       = var.docker_machine_version
+      docker_machine_download_url                                  = var.docker_machine_download_url
+      runners_config                                               = local.template_runner_config
+      runners_userdata                                             = var.runners_userdata
+      runners_executor                                             = var.runners_executor
+      runners_install_amazon_ecr_credential_helper                 = var.runners_install_amazon_ecr_credential_helper
+      curl_cacert                                                  = length(var.runners_gitlab_certificate) > 0 ? "--cacert /etc/gitlab-runner/certs/gitlab.crt" : ""
+      pre_install_certificates                                     = local.pre_install_certificates
+      pre_install                                                  = var.userdata_pre_install
+      post_install                                                 = var.userdata_post_install
+      runners_gitlab_url                                           = var.runners_gitlab_url
+      runners_token                                                = var.runners_token
+      secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
+      secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn
+      secure_parameter_store_gitlab_runner_registration_token_name = local.secure_parameter_store_gitlab_runner_registration_token_name
+      secure_parameter_store_region                                = var.aws_region
+      gitlab_runner_registration_token                             = lookup(var.gitlab_runner_registration_config, "registration_token", "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
+      gitlab_runner_description                                    = var.gitlab_runner_registration_config["description"]
+      gitlab_runner_tag_list                                       = var.gitlab_runner_registration_config["tag_list"]
+      gitlab_runner_locked_to_project                              = var.gitlab_runner_registration_config["locked_to_project"]
+      gitlab_runner_run_untagged                                   = var.gitlab_runner_registration_config["run_untagged"]
+      gitlab_runner_maximum_timeout                                = var.gitlab_runner_registration_config["maximum_timeout"]
+      gitlab_runner_access_level                                   = lookup(var.gitlab_runner_registration_config, "access_level", "not_protected")
+      sentry_dsn                                                   = var.sentry_dsn
+      public_key                                                   = var.use_fleet == true ? tls_private_key.fleet[0].public_key_openssh : ""
+      use_fleet                                                    = var.use_fleet
+      private_key                                                  = var.use_fleet == true ? tls_private_key.fleet[0].private_key_pem : ""
   })
 
   template_runner_config = templatefile("${path.module}/template/runner-config.tftpl",

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -36,7 +36,7 @@ gitlab_runner_registration_token=${gitlab_runner_registration_token}
 # fetch registration token from SSM
 if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
 then
-    gitlab_runner_registration_token=$(aws ssm get-parameters --names "${secure_parameter_store_registration_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
+    gitlab_runner_registration_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_runner_registration_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
 fi
 
 if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -32,10 +32,17 @@ then
   [[ "$valid_token_response" != "200" ]] && valid_token=false
 fi
 
+gitlab_runner_registration_token=${gitlab_runner_registration_token}
+# fetch registration token from SSM
+if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
+then
+    gitlab_runner_registration_token=$(aws ssm get-parameters --names "${secure_parameter_store_registration_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters | .[0] | .Value")
+fi
+
 if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
 then
   token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
-    --form "token=${gitlab_runner_registration_token}" \
+    --form "token=$gitlab_runner_registration_token" \
     --form "tag_list=${gitlab_runner_tag_list}" \
     --form "description=${gitlab_runner_description}" \
     --form "locked=${gitlab_runner_locked_to_project}" \

--- a/variables.tf
+++ b/variables.tf
@@ -615,10 +615,10 @@ variable "gitlab_runner_registration_config" {
   }
 }
 
-variable "secure_parameter_store_registration_token_key" {
-  description = "The key name used store the Gitlab runner registration token in Secure Parameter Store"
+variable "secure_parameter_store_gitlab_runner_registration_token_name" {
+  description = "The name of the SSM parameter to read the GitLab Runner registration token from."
   type        = string
-  default     = "registration-token"
+  default     = "gitlab-runner-registration-token"
 }
 
 variable "secure_parameter_store_runner_token_key" {

--- a/variables.tf
+++ b/variables.tf
@@ -615,6 +615,12 @@ variable "gitlab_runner_registration_config" {
   }
 }
 
+variable "secure_parameter_store_registration_token_key" {
+  description = "The key name used store the Gitlab runner registration token in Secure Parameter Store"
+  type        = string
+  default     = "registration-token"
+}
+
 variable "secure_parameter_store_runner_token_key" {
   description = "The key name used store the Gitlab runner token in Secure Parameter Store"
   type        = string


### PR DESCRIPTION
## Description

Adds the ability to read the Gitlab registration token from SSM. If no registration token is passed in, it will look in SSM to find the token to use. This prevents the token from being leaked as part of the user_data.

```hcl
module "gitlab_runner" {
  # ...
  gitlab_runner_registration_config = {
    registration_token = "" # this is the default value too
    # ...
  }

  secure_parameter_store_gitlab_runner_registration_token_name = "name-of-ssm-parameter-holding-the-registration-token"
```

Closes #776
Precondition for #186 to get rid of pre-registered runners.

## Migrations required

NO

## Verification

I modified the runner-default example to not pass in a registration token and added the token to SSM instead. Then I started up the runner and confirmed that it successfully registered with Gitlab.
