### PR TITLE
revert: removes the `nonsensitive` from `runner_user_data` output

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -54,6 +54,6 @@ output "runner_launch_template_name" {
 }
 
 output "runner_user_data" {
-  description = "The user data of the Gitlab Runner Agent's launch template."
-  value       = nonsensitive(local.template_user_data)
+  description = "(Deprecated) The user data of the Gitlab Runner Agent's launch template. Set `var.debug.output_runner_user_data_to_file` to true to write `user_data.sh`."
+  value       = local.template_user_data
 }


### PR DESCRIPTION
## Description

Removes the `nonsensitive` function as the value sometime is not sensitive and the function fails with

```
│ Error: Invalid function argument
│
│ on .terraform/modules/gitlab_runner_sare_pim_infrastructure/outputs.tf line 58, in output "runner_user_data":
│ 58: value = nonsensitive(local.template_user_data)
│ ├────────────────
│ │ while calling nonsensitive(value)
│ │ local.template_user_data is
```

The output is marked as deprecated and shouldn't be used any longer. Use `var.debug.output_runner_user_data_to_file = true` to write the user data as file to the local disk.

Closes #828 

## Migrations required

No

## Verification

No verification done.
