### PR TITLE
ci: fix PR title linter authorization problems

### DIFF
--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -13,61 +13,68 @@ on:
 permissions: read-all
 
 jobs:
-  main:
-    name: Validate PR title
+  validate-pr-title:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
       contents: read
       statuses: write
     steps:
-      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # ratchet:amannn/action-semantic-pull-request@v5
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          # Default: https://github.com/commitizen/conventional-commit-types
-          types: |
-            build
-            chore
-            ci
-            docs
-            feat
-            fix
-            perf
-            refactor
-            revert
-            style
-            test
-          # Configure which scopes are allowed.
-          # deps - dependency updates
-          # main - for release-please (scope used for releases)
-          scopes: |
-            deps
-            main
-          # Configure that a scope must always be provided.
-          requireScope: false
-          # Configure additional validation for the subject based on a regex.
-          # This example ensures the subject doesn't start with an uppercase character.
-          subjectPattern: ^(?![A-Z]).+$
-          # If `subjectPattern` is configured, you can use this property to override
-          # the default error message that is shown when the pattern doesn't match.
-          # The variables `subject` and `title` can be used within the message.
-          subjectPatternError: |
-            The subject "{subject}" found in the pull request title "{title}"
-            didn't match the configured pattern. Please ensure that the subject
-            doesn't start with an uppercase character.
-          # For work-in-progress PRs you can typically use draft pull requests
-          # from GitHub. However, private repositories on the free plan don't have
-          # this option and therefore this action allows you to opt-in to using the
-          # special "[WIP]" prefix to indicate this state. This will avoid the
-          # validation of the PR title and the pull request checks remain pending.
-          # Note that a second check will be reported if this is enabled.
-          wip: true
-          # When using "Squash and merge" on a PR with only one commit, GitHub
-          # will suggest using that commit message instead of the PR title for the
-          # merge commit, and it's easy to commit this by mistake. Enable this option
-          # to also validate the commit message for one commit PRs.
-          validateSingleCommit: false
-          # Related to `validateSingleCommit` you can opt-in to validate that the PR
-          # title matches a single commit to avoid confusion.
-          validateSingleCommitMatchesPrTitle: false
+    - uses: npalm/action-app-token@dd4bb16d91ced5659bc618705c96b822c5a42136 # ratchet:npalm/action-app-token@v1.1.0
+      id: token
+      with:
+        appId: ${{ secrets.PRLINT_APP_ID }}
+        appPrivateKeyBase64: ${{ secrets.PRLINT_APP_PRIVATE_KEY_BASE64 }}
+        appInstallationType: repo
+        appInstallationValue: ${{ github.repository }}
+
+    - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # ratchet:amannn/action-semantic-pull-request@v5
+      env:
+        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
+      with:
+        # Default: https://github.com/commitizen/conventional-commit-types
+        types: |
+          build
+          chore
+          ci
+          docs
+          feat
+          fix
+          perf
+          refactor
+          revert
+          style
+          test
+        # Configure which scopes are allowed.
+        # deps - dependency updates
+        # main - for release-please (scope used for releases)
+        scopes: |
+          deps
+          main
+        # Configure that a scope must always be provided.
+        requireScope: false
+        # Configure additional validation for the subject based on a regex.
+        # This example ensures the subject doesn't start with an uppercase character.
+        subjectPattern: ^(?![A-Z]).+$
+        # If `subjectPattern` is configured, you can use this property to override
+        # the default error message that is shown when the pattern doesn't match.
+        # The variables `subject` and `title` can be used within the message.
+        subjectPatternError: |
+          The subject "{subject}" found in the pull request title "{title}"
+          didn't match the configured pattern. Please ensure that the subject
+          doesn't start with an uppercase character.
+        # For work-in-progress PRs you can typically use draft pull requests
+        # from GitHub. However, private repositories on the free plan don't have
+        # this option and therefore this action allows you to opt-in to using the
+        # special "[WIP]" prefix to indicate this state. This will avoid the
+        # validation of the PR title and the pull request checks remain pending.
+        # Note that a second check will be reported if this is enabled.
+        wip: true
+        # When using "Squash and merge" on a PR with only one commit, GitHub
+        # will suggest using that commit message instead of the PR title for the
+        # merge commit, and it's easy to commit this by mistake. Enable this option
+        # to also validate the commit message for one commit PRs.
+        validateSingleCommit: false
+        # Related to `validateSingleCommit` you can opt-in to validate that the PR
+        # title matches a single commit to avoid confusion.
+        validateSingleCommitMatchesPrTitle: false

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -2,7 +2,7 @@
 name: "Lint PR title"
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - edited
@@ -20,17 +20,7 @@ jobs:
       contents: read
       statuses: write
     steps:
-    - uses: npalm/action-app-token@dd4bb16d91ced5659bc618705c96b822c5a42136 # ratchet:npalm/action-app-token@v1.1.0
-      id: token
-      with:
-        appId: ${{ secrets.PRLINT_APP_ID }}
-        appPrivateKeyBase64: ${{ secrets.PRLINT_APP_PRIVATE_KEY_BASE64 }}
-        appInstallationType: repo
-        appInstallationValue: ${{ github.repository }}
-
     - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # ratchet:amannn/action-semantic-pull-request@v5
-      env:
-        GITHUB_TOKEN: ${{ steps.token.outputs.token }}
       with:
         # Default: https://github.com/commitizen/conventional-commit-types
         types: |

--- a/.github/workflows/lint_pr_title.yml
+++ b/.github/workflows/lint_pr_title.yml
@@ -13,58 +13,61 @@ on:
 permissions: read-all
 
 jobs:
-  validate-pr-title:
+  main:
+    name: Validate PR title
     runs-on: ubuntu-latest
     permissions:
       pull-requests: read
       contents: read
       statuses: write
     steps:
-    - uses: amannn/action-semantic-pull-request@b6bca70dcd3e56e896605356ce09b76f7e1e0d39 # ratchet:amannn/action-semantic-pull-request@v5
-      with:
-        # Default: https://github.com/commitizen/conventional-commit-types
-        types: |
-          build
-          chore
-          ci
-          docs
-          feat
-          fix
-          perf
-          refactor
-          revert
-          style
-          test
-        # Configure which scopes are allowed.
-        # deps - dependency updates
-        # main - for release-please (scope used for releases)
-        scopes: |
-          deps
-          main
-        # Configure that a scope must always be provided.
-        requireScope: false
-        # Configure additional validation for the subject based on a regex.
-        # This example ensures the subject doesn't start with an uppercase character.
-        subjectPattern: ^(?![A-Z]).+$
-        # If `subjectPattern` is configured, you can use this property to override
-        # the default error message that is shown when the pattern doesn't match.
-        # The variables `subject` and `title` can be used within the message.
-        subjectPatternError: |
-          The subject "{subject}" found in the pull request title "{title}"
-          didn't match the configured pattern. Please ensure that the subject
-          doesn't start with an uppercase character.
-        # For work-in-progress PRs you can typically use draft pull requests
-        # from GitHub. However, private repositories on the free plan don't have
-        # this option and therefore this action allows you to opt-in to using the
-        # special "[WIP]" prefix to indicate this state. This will avoid the
-        # validation of the PR title and the pull request checks remain pending.
-        # Note that a second check will be reported if this is enabled.
-        wip: true
-        # When using "Squash and merge" on a PR with only one commit, GitHub
-        # will suggest using that commit message instead of the PR title for the
-        # merge commit, and it's easy to commit this by mistake. Enable this option
-        # to also validate the commit message for one commit PRs.
-        validateSingleCommit: false
-        # Related to `validateSingleCommit` you can opt-in to validate that the PR
-        # title matches a single commit to avoid confusion.
-        validateSingleCommitMatchesPrTitle: false
+      - uses: amannn/action-semantic-pull-request@c3cd5d1ea3580753008872425915e343e351ab54 # ratchet:amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          # Default: https://github.com/commitizen/conventional-commit-types
+          types: |
+            build
+            chore
+            ci
+            docs
+            feat
+            fix
+            perf
+            refactor
+            revert
+            style
+            test
+          # Configure which scopes are allowed.
+          # deps - dependency updates
+          # main - for release-please (scope used for releases)
+          scopes: |
+            deps
+            main
+          # Configure that a scope must always be provided.
+          requireScope: false
+          # Configure additional validation for the subject based on a regex.
+          # This example ensures the subject doesn't start with an uppercase character.
+          subjectPattern: ^(?![A-Z]).+$
+          # If `subjectPattern` is configured, you can use this property to override
+          # the default error message that is shown when the pattern doesn't match.
+          # The variables `subject` and `title` can be used within the message.
+          subjectPatternError: |
+            The subject "{subject}" found in the pull request title "{title}"
+            didn't match the configured pattern. Please ensure that the subject
+            doesn't start with an uppercase character.
+          # For work-in-progress PRs you can typically use draft pull requests
+          # from GitHub. However, private repositories on the free plan don't have
+          # this option and therefore this action allows you to opt-in to using the
+          # special "[WIP]" prefix to indicate this state. This will avoid the
+          # validation of the PR title and the pull request checks remain pending.
+          # Note that a second check will be reported if this is enabled.
+          wip: true
+          # When using "Squash and merge" on a PR with only one commit, GitHub
+          # will suggest using that commit message instead of the PR title for the
+          # merge commit, and it's easy to commit this by mistake. Enable this option
+          # to also validate the commit message for one commit PRs.
+          validateSingleCommit: false
+          # Related to `validateSingleCommit` you can opt-in to validate that the PR
+          # title matches a single commit to avoid confusion.
+          validateSingleCommitMatchesPrTitle: false


### PR DESCRIPTION
## Description

This PR fixes the authorization issues with the PR title linter GitHub workflow action.

In case the PR comes from a fork, the action wasn't able to lint the PR title as the `GITHUB_TOKEN` wasn't allowed to access the PR (created in our project). Error message shown: `Error: Resource not accessible by integration`.

As we verify the PR title only, we can simply run in `pull_request_target` instead of `pull_request`.

## Verification

Verified with [Hapag-Lloyd/test](https://github.com/Hapag-Lloyd/test) and [kayman-mk/test](https://github.com/kayman-mk/test)
