### PR TITLE
feat: add support for `wait_for_services_timeout` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@
 - [Prerequisites](#prerequisites)
 - [Usage](#usage)
 - [Examples](#examples)
-- [Contributors ✨](#contributors-) <!-- markdown-link-check-disable-line -->
-- [Requirements](#requirements) <!-- markdown-link-check-disable-line -->
-- [Providers](#providers) <!-- markdown-link-check-disable-line -->
-- [Modules](#modules) <!-- markdown-link-check-disable-line -->
-- [Resources](#resources) <!-- markdown-link-check-disable-line -->
-- [Inputs](#inputs) <!-- markdown-link-check-disable-line -->
-- [Outputs](#outputs) <!-- markdown-link-check-disable-line -->
+- [Contributors ✨](#contributors-)
+- [Module Documentation](#module-documentation)
+- [Requirements](#requirements)
+- [Providers](#providers)
+- [Modules](#modules)
+- [Resources](#resources)
+- [Inputs](#inputs)
+- [Outputs](#outputs)
 
 ## The module
 
@@ -37,7 +38,7 @@ The original setup of the module is based on the blog post: [Auto scale GitLab C
 > We know that this is a breaking change causing some pain, but we think it is worth it. We hope you agree. And to make the
 > transition as smooth as possible, we have added a migration script to the `migrations` folder. It will cover almost all cases,
 > but some minor rework might still be possible.
-> 
+>
 > Checkout [issue 819](https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/819)
 
 The runners created by the module use spot instances by default for running the builds using the `docker+machine` executor.
@@ -693,6 +694,7 @@ Made with [contributors-img](https://contrib.rocks).
 | <a name="input_runners_shm_size"></a> [runners\_shm\_size](#input\_runners\_shm\_size) | shm\_size for the runners, will be used in the runner config.toml | `number` | `0` | no |
 | <a name="input_runners_token"></a> [runners\_token](#input\_runners\_token) | Token for the runner, will be used in the runner config.toml. | `string` | `"__REPLACED_BY_USER_DATA__"` | no |
 | <a name="input_runners_use_private_address"></a> [runners\_use\_private\_address](#input\_runners\_use\_private\_address) | Restrict runners to the use of a private IP address. If `runner_agent_uses_private_address` is set to `true`(default), `runners_use_private_address` will also apply for the agent. | `bool` | `true` | no |
+| <a name="input_runners_wait_for_services_timeout"></a> [runners\_wait\_for\_services\_timeout](#input\_runners\_wait\_for\_services\_timeout) | How long to wait for Docker services. Set to `-1` to disable. Default is `30`. | `number` | `30` | no |
 | <a name="input_runners_userdata"></a> [runners\_userdata](#input\_runners\_userdata) | Cloud-init user data that will be passed to the runner ec2 instance. Available only for `docker+machine` driver. Should not be base64 encrypted. | `string` | `""` | no |
 | <a name="input_runners_volume_type"></a> [runners\_volume\_type](#input\_runners\_volume\_type) | Runner instance volume type | `string` | `"gp2"` | no |
 | <a name="input_runners_volumes_tmpfs"></a> [runners\_volumes\_tmpfs](#input\_runners\_volumes\_tmpfs) | Mount a tmpfs in runner container. https://docs.gitlab.com/runner/executors/docker.html#mounting-a-directory-in-ram | <pre>list(object({<br>    volume  = string<br>    options = string<br>  }))</pre> | `[]` | no |

--- a/README.md
+++ b/README.md
@@ -10,15 +10,14 @@
 - [Prerequisites](#prerequisites)
 - [Usage](#usage)
 - [Examples](#examples)
-- [Contributors ✨](#contributors-)
-- [Module Documentation](#module-documentation)
-- [Requirements](#requirements)
-- [Providers](#providers)
-- [Modules](#modules)
-- [Resources](#resources)
-- [Inputs](#inputs)
-- [Outputs](#outputs)
-
+- [Contributors ✨](#contributors-) <!-- markdown-link-check-disable-line -->
+- [Requirements](#requirements) <!-- markdown-link-check-disable-line -->
+- [Providers](#providers) <!-- markdown-link-check-disable-line -->
+- [Modules](#modules) <!-- markdown-link-check-disable-line -->
+- [Resources](#resources) <!-- markdown-link-check-disable-line -->
+- [Inputs](#inputs) <!-- markdown-link-check-disable-line -->
+- [Outputs](#outputs) <!-- markdown-link-check-disable-line -->
+- 
 ## The module
 
 This [Terraform](https://www.terraform.io/) modules creates a [GitLab CI runner](https://docs.gitlab.com/runner/). A blog post

--- a/main.tf
+++ b/main.tf
@@ -133,6 +133,7 @@ locals {
       runners_pre_build_script          = var.runners_pre_build_script
       runners_post_build_script         = var.runners_post_build_script
       runners_pre_clone_script          = var.runners_pre_clone_script
+      runners_wait_for_services_timeout = var.runners_wait_for_services_timeout
       runners_request_concurrency       = var.runners_request_concurrency
       runners_output_limit              = var.runners_output_limit
       runners_check_interval            = var.runners_check_interval

--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -29,6 +29,7 @@ listen_address = "${prometheus_listen_address}"
     pull_policy = ${runners_pull_policies}
     runtime = "${runners_docker_runtime}"
     helper_image = "${runners_helper_image}"
+    wait_for_services_timeout = "${runners_wait_for_services_timeout}"
     ${runners_docker_services}
   [runners.docker.tmpfs]
     ${runners_volumes_tmpfs}

--- a/variables.tf
+++ b/variables.tf
@@ -364,7 +364,7 @@ variable "runners_output_limit" {
 variable "runners_wait_for_services_timeout" {
   description = "How long to wait for Docker services. Set to -1 to disable. Default is 30."
   type        = number
-  default     = "30"
+  default     = 30
 }
 
 variable "userdata_pre_install" {

--- a/variables.tf
+++ b/variables.tf
@@ -361,6 +361,12 @@ variable "runners_output_limit" {
   default     = 4096
 }
 
+variable "runners_wait_for_services_timeout" {
+  description = "How long to wait for Docker services. Set to -1 to disable. Default is 30."
+  type        = number
+  default     = "30"
+}
+
 variable "userdata_pre_install" {
   description = "User-data script snippet to insert before GitLab runner install"
   type        = string


### PR DESCRIPTION
## Description

This PR adds the `wait_for_services_timeout` docker setting for the executor (see https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersdocker-section).

I've found #513 while looking for a solution to our problem. After migrating from the Kubernetes executer to the docker-machine executer, we have had a couple of Gitlab jobs that are always waiting 30s before actually running the defined steps.

I am aware of #819 but I believe this might be a quick win.

## Migrations required

 NO

## Test the change

In order to test my change, I recommend to set
```hcl
  debug = { "output_runner_config_to_file": true, "output_runner_user_data_to_file": false }
```

and then run `terraform plan`.

It will print the locally rendered `config.toml` that now contains the new setting:
```
[...]
  pre_clone_script = ""
  request_concurrency = 1
  output_limit = 4096
  limit = 0
  wait_for_services_timeout = 30
[...]
```

