### PR TITLE
fix(runner-config): wait_for_services_timeout needs to be an integer …

### DIFF
--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -29,7 +29,7 @@ listen_address = "${prometheus_listen_address}"
     pull_policy = ${runners_pull_policies}
     runtime = "${runners_docker_runtime}"
     helper_image = "${runners_helper_image}"
-    wait_for_services_timeout = "${runners_wait_for_services_timeout}"
+    wait_for_services_timeout = ${runners_wait_for_services_timeout}
     ${runners_docker_services}
   [runners.docker.tmpfs]
     ${runners_volumes_tmpfs}


### PR DESCRIPTION
## Description

The current runners config leads to this error when installing the gitlab runner service:
```sh
FATAL: toml: line 33 (last key "runners.docker.wait_for_services_timeout"): incompatible types: TOML value has type string; destination has type integer 
```

