### PR TITLE
docs: rename parameter in fleet example

### DIFF
--- a/README.md
+++ b/README.md
@@ -409,7 +409,7 @@ module "runner" {
 
   docker_machine_instance_types_fleet       = ["t3a.medium", "t3.medium", "t2.medium"]
   use_fleet                                 = true
-  key_pair_name                             = "<key_pair_name>"
+  fleet_key_pair_name                       = "<key_pair_name>"
 
   runners_name       = "docker-machine"
   runners_gitlab_url = "https://gitlab.com"


### PR DESCRIPTION
## Description

This PR fixes #877 describing an invalid parameter name in the example for spot fleets. The parameter `key_pair_name` was renamed to `fleet_key_pair_name`.

Closes #877 
