### PR TITLE
fix: add missing defaults

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -69,7 +69,7 @@ locals {
   secure_parameter_store_runner_sentry_dsn = "${var.environment}-${var.runner_sentry_secure_parameter_store_name}"
 
   # Custom names for runner agent instance, security groups, and IAM objects
-  name_runner_agent_instance = var.runner_instance.name_prefix == "" ? local.tags["Name"] : var.runner_instance.name_prefix
+  name_runner_agent_instance = var.runner_instance.name_prefix == null ? local.tags["Name"] : var.runner_instance.name_prefix
   name_sg                    = var.security_group_prefix == "" ? local.tags["Name"] : var.security_group_prefix
   name_iam_objects           = var.iam_object_prefix == "" ? local.tags["Name"] : var.iam_object_prefix
 

--- a/variables.tf
+++ b/variables.tf
@@ -325,8 +325,8 @@ variable "runner_gitlab" {
     certificate        = optional(string, "")
     registration_token = optional(string, "__REPLACED_BY_USER_DATA__")
     runner_version     = optional(string, "15.8.2")
-    url                = optional(string)
-    url_clone          = optional(string)
+    url                = optional(string, "")
+    url_clone          = optional(string, "")
   })
 }
 


### PR DESCRIPTION
While checking the PR, I was not able to switch from main to the refactory-varialbes branch for the example-default.

- fix a missing default
- add a null check in stated of a string check