### PR TITLE
fix: remove empty elements from tag list

### DIFF
--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -65,7 +65,7 @@ listen_address = "${prometheus_listen_address}"
       "amazonec2-request-spot-instance=${runners_request_spot_instance}",
       %{~ if runners_spot_price_bid != "" ~}"amazonec2-spot-price=${runners_spot_price_bid}",%{~ endif ~}
       "amazonec2-security-group=${runners_security_group_name}",
-      "amazonec2-tags=${runners_tags},__PARENT_TAG__",
+      "amazonec2-tags=${join(",", compact([runners_tags, "__PARENT_TAG__"]))}",
       "amazonec2-use-ebs-optimized-instance=${runners_ebs_optimized}",
       "amazonec2-monitoring=${runners_monitoring}",
       "amazonec2-iam-instance-profile=%{ if runners_iam_instance_profile_name != "" }${runners_iam_instance_profile_name}%{ else }${runners_instance_profile}%{ endif ~}",


### PR DESCRIPTION
## Description

In rare cases the `amazonec2-tags` may contain empty elements which show up as `,__PARENT_TAG__` which is not a valid value for AWS API to create an instance.

The problem is that `runner_tags` must be removed if it is empty. Otherwise the empty element is inserted into the final string which results in a preceding `,`.

Closes #933 

## Verification

Verified manually with
- no tags --> `__PARENT_TAG__`
- with tags --> `tag1,value1,__PARENT_TAG`
