### PR TITLE
feat: add `MaxGrowthRate` to limit the number of instances added in parallel

### DIFF
--- a/examples/runner-default/versions.tf
+++ b/examples/runner-default/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.14.0"
+      version = "5.15.0"
     }
     local = {
       source  = "hashicorp/local"

--- a/main.tf
+++ b/main.tf
@@ -107,6 +107,7 @@ locals {
       runners_spot_price_bid            = var.runner_worker_docker_machine_instance_spot.max_price == "on-demand-price" || var.runner_worker_docker_machine_instance_spot.max_price == null ? "" : var.runner_worker_docker_machine_instance_spot.max_price
       runners_ami                       = var.runner_worker.type == "docker+machine" ? data.aws_ami.docker-machine[0].id : ""
       runners_security_group_name       = var.runner_worker.type == "docker+machine" ? aws_security_group.docker_machine[0].name : ""
+      runners_max_growth_rate           = var.runner_worker_docker_machine_instance.max_growth_rate
       runners_monitoring                = var.runner_worker_docker_machine_instance.monitoring
       runners_ebs_optimized             = var.runner_worker_docker_machine_instance.ebs_optimized
       runners_instance_profile          = var.runner_worker.type == "docker+machine" ? aws_iam_instance_profile.docker_machine[0].name : ""

--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -75,6 +75,7 @@ listen_address = "${prometheus_listen_address}"
       %{~ endif ~}
       ${docker_machine_options}
     ]
+    MaxGrowthRate = ${runners_max_growth_rate}
 
 %{~ for config in runners_machine_autoscaling ~}
     [[runners.machine.autoscaling]]

--- a/variables.tf
+++ b/variables.tf
@@ -722,7 +722,6 @@ variable "runner_worker_docker_machine_ec2_metadata_options" {
 variable "runner_worker_docker_machine_autoscaling_options" {
   description = "Set autoscaling parameters based on periods, see https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersmachine-section"
   type = list(object({
-    max_growth_rate   = optional(number)
     periods           = list(string)
     idle_count        = optional(number)
     idle_scale_factor = optional(number)

--- a/variables.tf
+++ b/variables.tf
@@ -649,6 +649,7 @@ variable "runner_worker_docker_machine_instance" {
     ebs_optimized = Enable EBS optimization for the Runner Worker.
     idle_count = Number of idle Runner Worker instances (not working for the Docker Runner Worker) (IdleCount).
     idle_time = Idle time of the Runner Worker before they are destroyed (not working for the Docker Runner Worker) (IdleTime).
+    max_growth_rate = The maximum number of machines that can be added to the runner in parallel.
     monitoring = Enable detailed monitoring for the Runner Worker.
     name_prefix = Set the name prefix and override the `Name` tag for the Runner Worker.
     private_address_only = Restrict Runner Worker to the use of a private IP address. If `runner_instance.use_private_address_only` is set to `true` (default), `runner_worker_docker_machine_instance.private_address_only` will also apply for the Runner.
@@ -664,6 +665,7 @@ variable "runner_worker_docker_machine_instance" {
     ebs_optimized              = optional(bool, true)
     idle_count                 = optional(number, 0)
     idle_time                  = optional(number, 600)
+    max_growth_rate            = optional(number, 0)
     monitoring                 = optional(bool, false)
     name_prefix                = optional(string, "")
     private_address_only       = optional(bool, true)
@@ -720,6 +722,7 @@ variable "runner_worker_docker_machine_ec2_metadata_options" {
 variable "runner_worker_docker_machine_autoscaling_options" {
   description = "Set autoscaling parameters based on periods, see https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersmachine-section"
   type = list(object({
+    max_growth_rate   = optional(number)
     periods           = list(string)
     idle_count        = optional(number)
     idle_scale_factor = optional(number)


### PR DESCRIPTION
## Description

This feature allows to support `MaxGrowthRate` which limits the number of instances added in parallel by the Runner. The default of `0` (unlimited) is used if no value is given.

The parameter is added to `runner_worker_docker_machine_instance` as this is the only Runner type for which it makes sense. All other types are not able to scale and thus it is not a `runner_worker` parameter.

See [advanced-configuration](https://docs.gitlab.com/runner/configuration/advanced-configuration.html#the-runnersmachine-section)

Closes #851 

## Migrations required

NO

## Verification

- do not set the parameter --> `MaxGrowthRate` in config file is 0.
- set the parameter to any value --> `MaxGrowthRate` in config file is "any value"