### PR TITLE
fix: convert the fleet instance type in migration script

### DIFF
--- a/migrations/migrate-to-7-0-0.sh
+++ b/migrations/migrate-to-7-0-0.sh
@@ -521,9 +521,9 @@ extracted_variables=$(echo "$extracted_variables" | \
                       sed 's/runner_worker_docker_machine_instance_prefix/name_prefix/g'
                     )
 
-extracted_fleet_types=$(grep -E '(docker_machine_instance_types_fleet)' "$converted_file" | sed 's/docker_machine_instance_types_fleet/types/g')
+extracted_fleet_types=$(grep -E '(docker_machine_types_fleet)' "$converted_file" | sed 's/docker_machine_types_fleet/types/g')
 extracted_fleet_subnets=$(grep -E '(fleet_executor_subnet_ids)' "$converted_file" | sed 's/fleet_executor_subnet_ids/subnet_ids/g')
-sed -i '/docker_machine_instance_types_fleet/d' "$converted_file"
+sed -i '/docker_machine_types_fleet/d' "$converted_file"
 sed -i '/fleet_executor_subnet_ids/d' "$converted_file"
 
 # add new block runners_docker_options at the end


### PR DESCRIPTION
## Description

The instance types for the fleet are not converted. In this case the module uses a default value `m5.large`. So all created instances are `m5.large` instances which is usually not wanted.

If the migration script was used to convert the module call to version 7, it is very likely that you find the following in your module call:
```hcl
runner_instance = {
    docker_machine_types_fleet = ["t3.medium"] # your instance types here
}
```

The variable `docker_machine_types_fleet` does not exist, but Terraform does not report an error.

This PR fixes the migration script and produces the following correct code:
```hcl
runner_worker_docker_machine_instance = {
  types                    = ["t3.medium"]
}
```

## Migrations required

No

## Verification

Verified locally that the script produces the output as described above.
