### PR TITLE
chore: do all dependency updates once a week on the same day

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,13 +5,5 @@
     ":semanticCommitTypeAll(chore)",
     "group:all",
     "schedule:weekly"
-  ],
-  "ignorePaths": [],
-  "packageRules": [
-    {
-      "matchDatasources": ["terraform-provider"],
-      "groupName": "Terraform Providers",
-      "schedule": ["on sunday"]
-    }
   ]
 }


### PR DESCRIPTION
## Description

Terraform updates were scheduled for Sunday, everything else for once a week which could be another weekday. Now all dependency updates are done once a week.