### PR TITLE
chore: do not ignore any path when Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,5 +5,6 @@
     ":semanticCommitTypeAll(chore)",
     "group:all",
     "schedule:weekly"
-  ]
+  ],
+  "ignorePaths": []
 }


### PR DESCRIPTION
## Description

We should update the dependencies in all directories. Do not leave anything out.
