### PR TITLE
fix: add kms:Encrypt permission, as needed since f25a86b5

### DIFF
--- a/policies/instance-kms-policy.json
+++ b/policies/instance-kms-policy.json
@@ -3,6 +3,7 @@
     "Statement": [
         {
             "Action": [
+                "kms:Encrypt",
                 "kms:Decrypt",
                 "kms:GenerateDataKey"
             ],


### PR DESCRIPTION
## Description

Since the [addition of KeyId](https://github.com/cattle-ops/terraform-aws-gitlab-runner/commit/f25a86b5ada3e78a56c33db07a0110354f5e2e5d#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR18) to the SSM parameter used to store the registration token, the replacement of the parameter following a failed token verification fails.  This is due to a missing Encrypt permission on the customer managed KMS key.

The initial put-parameter presumably passes due to a shortcut on the encryption when the value is null, but the [subsequent overwrite attempt](https://github.com/cattle-ops/terraform-aws-gitlab-runner/blob/5100efd3445c3f06e5089d970da5a3a0341624eb/template/gitlab-runner.tftpl#L53) fails.

## Migrations required

NO

## Verification

Manual addition of the kms:Encrypt permission has been proved to resolve the runner start-up failure
