### PR TITLE
fix: delete the 'runner_config_toml_rendereded' output variable

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -57,8 +57,3 @@ output "runner_user_data" {
   description = "(Deprecated) The user data of the Gitlab Runner Agent's launch template. Set `var.debug.output_runner_user_data_to_file` to true to write `user_data.sh`."
   value       = nonsensitive(local.template_user_data)
 }
-
-output "runner_config_toml_rendered" {
-  description = "The rendered config.toml given to the Runner Manager."
-  value       = local.template_runner_config
-}


### PR DESCRIPTION
## Description

Due to calls to `nonsensitive` in case the data is sensitive or not calling the function in the other case, the code gets very complex. The output variable `runner_config_toml_rendereded` was introduced for easier debugging, but we still have the option to write the whole Runner configuration to a local file (`debug.write_runner_config_to_file`).

This "fixers" that issue by just deleting the output variable.

Closes #1018

## Migrations required

Usually not. For debugging purposes, set the `debug.write_runner_config_to_file` to `true`. The configuration is written to a file on your local disk (directory `debug/`)

## Verification

Only linted as this is only deleting an output variable.
