### PR TITLE
fix: run the GitLab Runner deregistration process at shutdown

### DIFF
--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -155,77 +155,40 @@ then
   docker-machine rm -y dummy-machine
   unset HOME
   unset USER
-
 fi
 
-# A small script to remove this runner from being registered with Gitlab.
-cat <<REM > /etc/rc.d/init.d/remove_gitlab_registration
+# A small script to remove this runner from being registered with Gitlab. Executed at shutdown.
+cat <<EOF > /etc/systemd/system/remove-gitlab-registration.service
+[Unit]
+Description=Remove the GitLab Runner from GitLab at shutdown
+After=network-online.target
+Wants=network-online.target
+Before=shutdown.target reboot.target halt.target kexec.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/true
+ExecStop=/opt/remove_gitlab_registration.sh
+
+[Install]
+WantedBy=multi-user.target
+
+EOF
+
+cat <<EOF > /opt/remove_gitlab_registration.sh
 #!/bin/bash
-# chkconfig: 1356 99 03
-# description: cleans up gitlab runner key
-# processname: remove_runner_key
-#              /etc/rc.d/init.d/remove_gitlab_registration
-lockfile=/var/lock/subsys/remove_gitlab_registration
+echo "Removing Gitlab Runner ..."
+aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="null" 2>&1
+curl -sS ${curl_cacert} --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token" 2>&1
 
-# This lockfile is necessary so that we'll run the cleanup later.
-start() {
-    logger "Setting up Runner Removal Lockfile"
-    touch \$lockfile
-}
+EOF
 
-# Overwrite token in SSM with null and remove runner from Gitlab
-stop() {
-    logger "Removing Gitlab Runner Token"
-    aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="null" 2>&1 | logger &
-    curl -sS ${curl_cacert} --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token" 2>&1 | logger &
-    retval=\$?
-    rm -f \$lockfile
-    return \$retval
-}
+chmod a+x /opt/remove_gitlab_registration.sh
+systemctl enable remove-gitlab-registration.service
 
-# Map these to start just to be redunant.
-# We don't want to run Stop outside of shutdown.
-restart() {
-  start
-}
-reload() {
-  start
-}
-
-# Do nothing - there's no status.
-status() {
-  :
-}
-
-case "\$1" in
-    start)
-        \$1
-        ;;
-    stop)
-        \$1
-        ;;
-    restart)
-        \$1
-        ;;
-    status)
-        \$1
-        ;;
-    *)
-        echo "Usage: \$0 {start|stop|status|restart}"
-        exit 2
-        ;;
-esac
-REM
-
-chmod a+x /etc/init.d/remove_gitlab_registration
-
-# Use chkconfig to link into the runlevel 0 (shutdown) directories
-# This adds "start" scripts to levels 1,3,5, and 6, and a "stop" to the others.
-# This way we'll not be assigned jobs if we're shutting down, and clean up in Gitlab.
-chkconfig --add remove_gitlab_registration
-
-# As noted above, this does nothing more than make the lockfile.
-service remove_gitlab_registration start
+# start the service. Otherwise the stop action will not be triggered at shutdown.
+service remove-gitlab-registration start
 
 if ! ( rpm -q gitlab-runner >/dev/null )
 then


### PR DESCRIPTION
## Description

We have a script which removes the GitLab Runner from GitLab in case it is shutdown. This script wasn't run automatically. This PR adds a Systemd service which starts the removal script at shutdown automatically.

Closes #1014 

## Migrations required

No

## Verification

Verified manually that the Runner is removed from GitLab at shutdown.
