### PR TITLE
ci: exempt issues and PRs from becoming stale automatically

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -22,5 +22,7 @@ jobs:
           close-pr-message: 'This PR was closed because it has been stalled for 15 days with no activity.'
           days-before-stale: 60
           days-before-close: 15
+          exempt-issue-labels: 'work-in-progress'
+          exempt-pr-labels: 'work-in-progress'
           stale-issue-label: 'stale'
           stale-pr-label: 'stale'


### PR DESCRIPTION
## Description

Some of the issues/PRs are long-lived. But they are set to stale after some weeks. As it creates some manual workload to remove the stale label, this PR introduces a `work-in-progress` label. Issues/PRs with this label are never set to stale.

## Migrations required

No

## Verification

None
