### PR TITLE
ci: activate the auto-merge of non-major updates

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -28,6 +28,7 @@
     "noexec",
     "nolint",
     "npalm",
+    "platformAutomerge",
     "pylint",
     "pylintrc",
     "pyright",
@@ -57,6 +58,7 @@
   ],
   "words": [
     "aquasecurity",
+    "automerge",
     "backports",
     "blockquotes",
     "codeowners",

--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,7 @@
     "group:all",
     "schedule:weekly"
   ],
-  "ignorePaths": ["**/.terraform-version"]
+  "ignorePaths": ["**/.terraform-version"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],

--- a/renovate.json
+++ b/renovate.json
@@ -7,4 +7,15 @@
     "schedule:weekly"
   ],
   "ignorePaths": ["**/.terraform-version"]
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "automerge": true
+    }
+  ],
+  "platformAutomerge": true
 }


### PR DESCRIPTION
Configures Renovate to auto-merge all PRs which are releated to non-major updates.