### PR TITLE
ci: use a PAT to approve the Renovate pull requests

### DIFF
--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -4,9 +4,6 @@ name: Approve all Renovate PRs automatically
 # yamllint disable-line rule:truthy
 on: pull_request_target
 
-permissions:
-  contents: read
-
 jobs:
   auto-approve:
     runs-on: ubuntu-latest
@@ -14,7 +11,7 @@ jobs:
       pull-requests: write
     if: github.actor == 'renovate[bot]'
     steps:
-      # yamllint disable-line rule:comments
-      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4 # v3.2.1
+      - uses: hmarr/auto-approve-action@44888193675f29a83e04faf4002fa8c0b537b1e4  # v3.2.1
         with:
-          review-message: "Auto approved automated PR"
+          review-message: "Auto approved Renovate PR by organization"
+          github-token: ${{ secrets.AUTO_APPROVE_TOKEN }}

--- a/.github/workflows/auto-approval.yml
+++ b/.github/workflows/auto-approval.yml
@@ -4,6 +4,9 @@ name: Approve all Renovate PRs automatically
 # yamllint disable-line rule:truthy
 on: pull_request_target
 
+permissions:
+  contents: read
+  
 jobs:
   auto-approve:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Use a GitHub PAT to approve the Renovate pull requests. This saves some time as we can merge these pull requests automatically. Tokens generated by an app do not work here as apps can't be added to the `CODEOWNERS` file. So their approvals never count.