### PR TITLE
fix: add missing GetParameter policy

### DIFF
--- a/policies/instance-secure-parameter-role-policy.json
+++ b/policies/instance-secure-parameter-role-policy.json
@@ -11,6 +11,7 @@
         {
             "Effect": "Allow",
             "Action": [
+                "ssm:GetParameter",
                 "ssm:GetParameters"
             ],
             "Resource": "arn:${partition}:ssm:*"


### PR DESCRIPTION
## Description

This pull request addresses a bug where utilizing the module with 'access_token_secure_parameter_store_name' instead of 'registration_token' results in a failure to retrieve the parameter value, leading to an error. The issue manifests when the module is applied, and subsequent attempts by the EC2 instance to fetch the parameter during runtime result in a 'permission denied' error, as observed in CloudWatch logs

Closes #1057 

## Migrations required

No