### PR TITLE
fix: repair errors in startup shell script

### DIFF
--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -49,7 +49,7 @@ then
     # fetch gitlab token from SSM
     gitlab_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
 
-    response = $(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/user/runners" \
+    response=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/user/runners" \
       --header "private-token: $gitlab_token" \
       --form "tag_list=${gitlab_runner_tag_list}" \
       --form "description=${gitlab_runner_description}" \
@@ -60,10 +60,12 @@ then
       $runner_type_param \
       --form "access_level=${gitlab_runner_access_level}")
 
-    token = $(echo response | jq -r '.token')
+    token=$(echo response | jq -r '.token')
     if [[ "$token" == null ]]
-        message = $(echo response | jq -r '.message // .error_description')
+    then
+        message=$(echo response | jq -r '.message // .error_description')
         if [[ "$message" != null ]]
+        then
             echo "ERROR: Couldn't register the Runner. GitLab API call returned $message".
             exit 1
         fi

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -60,10 +60,10 @@ then
       $runner_type_param \
       --form "access_level=${gitlab_runner_access_level}")
 
-    token=$(echo response | jq -r '.token')
+    token=$(echo $response | jq -r '.token')
     if [[ "$token" == null ]]
     then
-        message=$(echo response | jq -r '.message // .error_description')
+        message=$(echo $response | jq -r '.message // .error_description')
         if [[ "$message" != null ]]
         then
             echo "ERROR: Couldn't register the Runner. GitLab API call returned $message".


### PR DESCRIPTION
## Description

The startup shell script of the Agent instance was broken due to missing tests (to be addressed in #1088 ). Fixed the script and validated it with shellchecker.

- `if` needs `then`
- no spaces in `=` assignments
- use `$` to get the value of a variable

## Verification

- module deployed in the test environment. Runners were spawn, jobs processed.
- Cloudwatch logs checked for errors, none found
