### PR TITLE
Fix bug when token is null

### DIFF
--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -25,6 +25,8 @@ if [[ "$token" != "null" ]]
 then
   valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
   [[ "$valid_token_response" != "200" ]] && valid_token=false
+else
+  valid_token=false
 fi
 
 if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]


### PR DESCRIPTION
## Description
EDIT: My resolution logic is flawed. I need to review this repo code before moving this out of draft. There's a definitely a bug in the tpl somewhere



Currently I redeploy my runners using this module weekly to get the latest AMI. When there are AMI changes, the script "/opt/remove_gitlab_registration.sh" is executed which sets the parameter "secure_parameter_store_runner_token_key" to null. As a result of this NULL value, the following code fails when trying to bring the runners back online.

```

valid_token=true
if [[ "$token" != "null" ]]                   
then
  valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
  [[ "$valid_token_response" != "200" ]] && valid_token=false
fi

if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
then
```


## Migrations required

None.

## Verification

Please mention how you test the changes. Ideally add automated tests (see tests/ folder)
