### PR TITLE
feat: add option to use a pre-registered Runner

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -5,12 +5,12 @@ Common pitfalls are documented in [pitfalls.md](pitfalls.md).
 ## Configuration
 
 The examples are configured with defaults that should work in general. The examples are in general configured for the
-region Ireland `eu-west-1`. The only parameter that needs to be provided is the GitLab are the registration token and the
-URL of your GitLab instance. The token can be found in GitLab in the runner section (global, group or repo scope).
-Create a file `terraform.tfvars` and the registration token.
+region Ireland `eu-west-1`. The only parameter that needs to be provided is the name of a SSM parameter holding the Runner
+registration token and the URL of your GitLab instance. The Runner token is created in GitLab during the Runner registration process.
+Create a file `terraform.tfvars` and put the Runner registration token in the SSM parameter.
 
 ```hcl
-registration_token = "MY_TOKEN"
+preregistered_runner_token_ssm_parameter_name = "my-gitlab-runner-token-ssm-parameter-name"
 gitlab_url   = "https://my.gitlab.instance/"
 ```
 
@@ -18,16 +18,9 @@ The base image used to host the GitLab Runner agent is the latest available Amaz
 this module a hard coded list of AMIs per region was provided. This list has been replaced by a search filter to find the latest
 AMI. Setting the filter to `amzn2-ami-hvm-2.0.20200207.1-x86_64-ebs` will allow you to version lock the target AMI if needed.
 
-> 💥  **If you are using GitLab >= 16.0.0**: `registration_token` will be deprecated!
-
->GitLab >= 16.0.0 has removed the `registration_token` since they are working on a [new token architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens/).
-> This module handle these changes, you need to provide a personal access token with `api` scope for the runner to authenticate
-> itself.
-
->The workflow is as follows ([migration steps](https://github.com/cattle-ops/terraform-aws-gitlab-runner/pull/876)):
->1. The runner make an API call (with the access token) to create a new runner on GitLab depending on its type (`instance`, `group` or `project`).
->2. GitLab answers with a token prefixed by `glrt-` and we put it in SSM.
->3. The runner will get the config from `/etc/gitlab-runner/config.toml` and will listen for new jobs from your GitLab instance.
+The Runner uses a token to register with GitLab. This token is stored in the AWS SSM parameter store. The token has to be created
+manually in GitLab and stored in the SSM parameter store. All other registration methods are deprecated and will be removed in
+v8.0.0.
 
 ## Install the module
 
@@ -47,40 +40,7 @@ terraform destroy
 
 ## Scenarios
 
-### Scenario: Basic usage on GitLab **< 16.0.0**
-
-Below is a basic examples of usages of the module. Regarding the dependencies such as a VPC, have a look at the [default example](https://github.com/cattle-ops/terraform-aws-gitlab-runner/tree/main/examples/runner-default).
-
-```hcl
-module "runner" {
-  # https://registry.terraform.io/modules/cattle-ops/gitlab-runner/aws/
-  source  = "cattle-ops/gitlab-runner/aws"
-
-  environment = "basic"
-
-  vpc_id    = module.vpc.vpc_id
-  subnet_id = element(module.vpc.private_subnets, 0)
-
-  runner_gitlab = {
-    url = "https://gitlab.com"
-  }
-
-  runner_gitlab_registration_config = {
-    registration_token = "my-token"
-    tag_list           = "docker"
-    description        = "runner default"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
-  }
-
-  runner_worker_docker_machine_instance = {
-    subnet_ids = module.vpc.private_subnets
-  }
-}
-```
-
-### Scenario: Basic usage on GitLab **>= 16.0.0**
+### Scenario: Basic usage
 
 Below is a basic examples of usages of the module if your GitLab instance version is >= 16.0.0.
 
@@ -101,20 +61,9 @@ module "runner" {
    
   runner_gitlab = {
     url = "https://gitlab.com"
-    access_token_secure_parameter_store_name = "gitlab_access_token_ssm_name"
+     
+    preregistered_runner_token_ssm_parameter_name = "my-gitlab-runner-token-ssm-parameter-name"
   }
-   
-  runner_gitlab_registration_config = {
-    type               = "instance" # or "group" or "project"
-    # group_id           = 1234 # for "group"
-    # project_id         = 5678 # for "project"
-    tag_list           = "docker"
-    description        = "runner default"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
-  }
-
 }
 ```
 
@@ -137,15 +86,8 @@ module "runner" {
    
   runner_gitlab = {
     url = "https://gitlab.com"
-  }
-   
-  runner_gitlab_registration_config = {
-    registration_token = "my-token"
-    tag_list           = "docker"
-    description        = "runner default"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
+
+    preregistered_runner_token_ssm_parameter_name = "my-gitlab-runner-token-ssm-parameter-name"
   }
    
    runner_worker_cache = {
@@ -183,16 +125,9 @@ module "runner" {
 
   runner_gitlab = {
     url = "https://gitlab.com"
- }
 
-  runner_gitlab_registration_config = {
-    registration_token = "my-token"
-    tag_list           = "docker"
-    description        = "runner default"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
-  }
+    preregistered_runner_token_ssm_parameter_name = "my-gitlab-runner-token-ssm-parameter-name"
+ }
 
   runner_worker = {
     type = "docker+machine"
@@ -244,52 +179,6 @@ resource "aws_iam_service_linked_role" "autoscaling" {
 If a KMS key is set via `kms_key_id`, make sure that you also give proper access to the key. Otherwise, you might
 get errors, e.g. the build cache can't be decrypted or logging via CloudWatch is not possible. For a CloudWatch
 example checkout [kms-policy.json](https://github.com/cattle-ops/terraform-aws-gitlab-runner/blob/main/policies/kms-policy.json)
-
-### GitLab runner token configuration
-
-By default, the runner is registered on initial deployment. In previous versions of this module this was a manual process. The
-manual process is still supported but will be removed in future releases. The runner token will be stored in the AWS SSM parameter
-store. See [example](../examples/runner-pre-registered) for more details.
-
-To register the runner automatically set the variable `gitlab_runner_registration_config["registration_token"]`. This token value
-can be found in your GitLab project, group, or global settings. For a generic runner you can find the token in the admin section.
-By default, the runner will be locked to the target project and not run untagged jobs. Below is an example of the configuration map.
-
-```hcl
-runner_gitlab_registration_config = {
-  registration_token = "<registration token>"
-  tag_list           = "<your tags, comma separated>"
-  description        = "<some description>"
-  locked_to_project  = "true"
-  run_untagged       = "false"
-  maximum_timeout    = "3600"
-  # ref_protected runner will only run on pipelines triggered on protected branches. Defaults to not_protected
-  access_level       = "<not_protected OR ref_protected>"
-}
-```
-
-The registration token can also be read in via SSM parameter store. If no registration token is passed in, the module
-will look up the token in the SSM parameter store at the location specified by
-`runner_gitlab_registration_token_secure_parameter_store_name`.
-
-For migration to the new setup simply add the runner token to the parameter store. Once the runner is started it will look up the
-required values via the parameter store. If the value is `null` a new runner will be registered and a new token created/stored.
-
-```sh
-# set the following variables, look up the variables in your Terraform config.
-# see your Terraform variables to fill in the vars below.
-aws-region=<${var.aws_region}>
-token=<runner-token-see-your-gitlab-runner>
-parameter-name=<${var.environment}>-<${var.secure_parameter_store_runner_token_key}>
-
-aws ssm put-parameter --overwrite --type SecureString  --name "${parameter-name}" --value ${token} --region "${aws-region}"
-```
-
-Once you have created the parameter, you must remove the variable `runner_gitlab.registration_token` from your config. The next
-time your GitLab runner instance is created it will look up the token from the SSM parameter store.
-
-Finally, the runner still supports the manual runner creation. No changes are required. Please keep in mind that this setup will be
-removed in future releases.
 
 ### Auto Scaling Group
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -20,7 +20,9 @@ AMI. Setting the filter to `amzn2-ami-hvm-2.0.20200207.1-x86_64-ebs` will allow 
 
 > 💥  **If you are using GitLab >= 16.0.0**: `registration_token` will be deprecated!
 
->GitLab >= 16.0.0 has removed the `registration_token` since they are working on a [new token architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens/). This module handle these changes, you need to provide a personal access token with `api` scope for the runner to authenticate itself.
+>GitLab >= 16.0.0 has removed the `registration_token` since they are working on a [new token architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens/).
+> This module handle these changes, you need to provide a personal access token with `api` scope for the runner to authenticate
+> itself.
 
 >The workflow is as follows ([migration steps](https://github.com/cattle-ops/terraform-aws-gitlab-runner/pull/876)):
 >1. The runner make an API call (with the access token) to create a new runner on GitLab depending on its type (`instance`, `group` or `project`).

--- a/examples/runner-certificates/main.tf
+++ b/examples/runner-certificates/main.tf
@@ -42,11 +42,6 @@ module "vpc_endpoints" {
   }
 }
 
-resource "aws_ssm_parameter" "gitlab_runner_token" {
-  name  = "/gitlab/runner/registration-token"
-  type  = "SecureString"
-  value = "better set this manually and use a data statement here!"
-}
 
 module "runner" {
   source = "../../"
@@ -64,7 +59,7 @@ module "runner" {
   # Other public certs relating to my company.
   runner_gitlab = {
     url                                           = var.gitlab_url
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
 
     certificate    = file("${path.module}/my_gitlab_instance_cert.crt")
     ca_certificate = file("${path.module}/my_company_ca_cert_bundle.crt")

--- a/examples/runner-certificates/main.tf
+++ b/examples/runner-certificates/main.tf
@@ -42,6 +42,12 @@ module "vpc_endpoints" {
   }
 }
 
+resource "aws_ssm_parameter" "gitlab_runner_token" {
+  name  = "/gitlab/runner/registration-token"
+  type  = "SecureString"
+  value = "better set this manually and use a data statement here!"
+}
+
 module "runner" {
   source = "../../"
 
@@ -58,6 +64,8 @@ module "runner" {
   # Other public certs relating to my company.
   runner_gitlab = {
     url            = var.gitlab_url
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+
     certificate    = file("${path.module}/my_gitlab_instance_cert.crt")
     ca_certificate = file("${path.module}/my_company_ca_cert_bundle.crt")
   }
@@ -72,18 +80,6 @@ module "runner" {
       "/cache",
       "/etc/gitlab-runner/certs/:/etc/gitlab-runner/certs:ro"
     ]
-  }
-
-  ###############################################
-  # Registration
-  ###############################################
-  runner_gitlab_registration_config = {
-    registration_token = var.registration_token
-    tag_list           = "docker_runner"
-    description        = "runner docker - auto"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
   }
 
   ###############################################

--- a/examples/runner-certificates/main.tf
+++ b/examples/runner-certificates/main.tf
@@ -63,7 +63,7 @@ module "runner" {
   # Public cert of my company's gitlab instance
   # Other public certs relating to my company.
   runner_gitlab = {
-    url            = var.gitlab_url
+    url                                           = var.gitlab_url
     preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
 
     certificate    = file("${path.module}/my_gitlab_instance_cert.crt")

--- a/examples/runner-certificates/variables.tf
+++ b/examples/runner-certificates/variables.tf
@@ -22,8 +22,7 @@ variable "gitlab_url" {
   default     = "https://gitlab.com"
 }
 
-variable "registration_token" {
-  description = "Gitlab runner registration token"
+variable "preregistered_runner_token_ssm_parameter_name" {
+  description = "The name of the SSM parameter to read the preregistered GitLab Runner token from."
   type        = string
-  default     = "something"
 }

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -47,6 +47,12 @@ module "vpc_endpoints" {
   }
 }
 
+resource "aws_ssm_parameter" "gitlab_runner_token" {
+  name  = "/gitlab/runner/registration-token"
+  type  = "SecureString"
+  value = "better set this manually and use a data statement here!"
+}
+
 module "runner" {
   source = "../../"
 
@@ -67,15 +73,8 @@ module "runner" {
 
   runner_gitlab = {
     url = var.gitlab_url
-  }
 
-  runner_gitlab_registration_config = {
-    registration_token = var.registration_token
-    tag_list           = "docker_spot_runner"
-    description        = "runner default - auto"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
   }
 
   runner_worker_gitlab_pipeline = {

--- a/examples/runner-default/main.tf
+++ b/examples/runner-default/main.tf
@@ -47,12 +47,6 @@ module "vpc_endpoints" {
   }
 }
 
-resource "aws_ssm_parameter" "gitlab_runner_token" {
-  name  = "/gitlab/runner/registration-token"
-  type  = "SecureString"
-  value = "better set this manually and use a data statement here!"
-}
-
 module "runner" {
   source = "../../"
 
@@ -74,7 +68,7 @@ module "runner" {
   runner_gitlab = {
     url = var.gitlab_url
 
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }
 
   runner_worker_gitlab_pipeline = {

--- a/examples/runner-default/variables.tf
+++ b/examples/runner-default/variables.tf
@@ -22,8 +22,8 @@ variable "gitlab_url" {
   default     = "https://gitlab.com"
 }
 
-variable "registration_token" {
-  description = "Registration token for the runner."
+variable "preregistered_runner_token_ssm_parameter_name" {
+  description = "The name of the SSM parameter to read the preregistered GitLab Runner token from."
   type        = string
 }
 

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -38,6 +38,12 @@ module "vpc_endpoints" {
   }
 }
 
+resource "aws_ssm_parameter" "gitlab_runner_token" {
+  name  = "/gitlab/runner/registration-token"
+  type  = "SecureString"
+  value = "better set this manually and use a data statement here!"
+}
+
 module "runner" {
   source = "../../"
 
@@ -56,15 +62,8 @@ module "runner" {
 
   runner_gitlab = {
     url = var.gitlab_url
-  }
 
-  runner_gitlab_registration_config = {
-    registration_token = var.registration_token
-    tag_list           = "docker_runner"
-    description        = "runner docker - auto"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
   }
 
   runner_worker = {

--- a/examples/runner-docker/main.tf
+++ b/examples/runner-docker/main.tf
@@ -38,12 +38,6 @@ module "vpc_endpoints" {
   }
 }
 
-resource "aws_ssm_parameter" "gitlab_runner_token" {
-  name  = "/gitlab/runner/registration-token"
-  type  = "SecureString"
-  value = "better set this manually and use a data statement here!"
-}
-
 module "runner" {
   source = "../../"
 
@@ -63,7 +57,7 @@ module "runner" {
   runner_gitlab = {
     url = var.gitlab_url
 
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }
 
   runner_worker = {

--- a/examples/runner-docker/variables.tf
+++ b/examples/runner-docker/variables.tf
@@ -22,7 +22,7 @@ variable "gitlab_url" {
   default     = "https://gitlab.com"
 }
 
-variable "registration_token" {
-  description = "Registration token for the runner."
+variable "preregistered_runner_token_ssm_parameter_name" {
+  description = "The name of the SSM parameter to read the preregistered GitLab Runner token from."
   type        = string
 }

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -54,7 +54,7 @@ module "runner" {
   }
 
   runner_gitlab = {
-    url                = var.gitlab_url
+    url = var.gitlab_url
 
     preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -42,12 +42,6 @@ module "vpc_endpoints" {
   }
 }
 
-resource "aws_ssm_parameter" "gitlab_runner_token" {
-  name  = "/gitlab/runner/registration-token"
-  type  = "SecureString"
-  value = "better set this manually and use a data statement here!"
-}
-
 module "runner" {
   source = "../../"
 
@@ -62,7 +56,7 @@ module "runner" {
   runner_gitlab = {
     url                = var.gitlab_url
 
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }
 
   # working 9 to 5 :)

--- a/examples/runner-pre-registered/main.tf
+++ b/examples/runner-pre-registered/main.tf
@@ -42,6 +42,12 @@ module "vpc_endpoints" {
   }
 }
 
+resource "aws_ssm_parameter" "gitlab_runner_token" {
+  name  = "/gitlab/runner/registration-token"
+  type  = "SecureString"
+  value = "better set this manually and use a data statement here!"
+}
+
 module "runner" {
   source = "../../"
 
@@ -55,7 +61,8 @@ module "runner" {
 
   runner_gitlab = {
     url                = var.gitlab_url
-    registration_token = var.runner_token
+
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
   }
 
   # working 9 to 5 :)

--- a/examples/runner-pre-registered/variables.tf
+++ b/examples/runner-pre-registered/variables.tf
@@ -20,8 +20,8 @@ variable "gitlab_url" {
   type        = string
 }
 
-variable "runner_token" {
-  description = "Token for the runner, will be used in the runner config.toml"
+variable "preregistered_runner_token_ssm_parameter_name" {
+  description = "The name of the SSM parameter to read the preregistered GitLab Runner token from."
   type        = string
 }
 

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -26,12 +26,6 @@ module "cache" {
   environment = var.environment
 }
 
-resource "aws_ssm_parameter" "gitlab_runner_token" {
-  name  = "/gitlab/runner/registration-token"
-  type  = "SecureString"
-  value = "better set this manually and use a data statement here!"
-}
-
 module "runner" {
   source = "../../"
 
@@ -49,7 +43,7 @@ module "runner" {
   runner_gitlab = {
     url = var.gitlab_url
 
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }
 
   runner_worker = {

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -26,6 +26,12 @@ module "cache" {
   environment = var.environment
 }
 
+resource "aws_ssm_parameter" "gitlab_runner_token" {
+  name  = "/gitlab/runner/registration-token"
+  type  = "SecureString"
+  value = "better set this manually and use a data statement here!"
+}
+
 module "runner" {
   source = "../../"
 
@@ -42,16 +48,8 @@ module "runner" {
 
   runner_gitlab = {
     url = var.gitlab_url
-  }
 
-  runner_gitlab_registration_config = {
-    registration_token = var.registration_token
-    tag_list           = "docker_spot_runner"
-    description        = "runner public - auto"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
-    access_level       = "ref_protected"
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
   }
 
   runner_worker = {
@@ -89,15 +87,8 @@ module "runner2" {
 
   runner_gitlab = {
     url = var.gitlab_url
-  }
 
-  runner_gitlab_registration_config = {
-    registration_token = var.registration_token
-    tag_list           = "docker_spot_runner_2"
-    description        = "runner public - auto"
-    locked_to_project  = "true"
-    run_untagged       = "false"
-    maximum_timeout    = "3600"
+    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
   }
 
   runner_worker_cache = {

--- a/examples/runner-public/main.tf
+++ b/examples/runner-public/main.tf
@@ -82,7 +82,7 @@ module "runner2" {
   runner_gitlab = {
     url = var.gitlab_url
 
-    preregistered_runner_token_ssm_parameter_name = aws_ssm_parameter.gitlab_runner_token.name
+    preregistered_runner_token_ssm_parameter_name = var.preregistered_runner_token_ssm_parameter_name
   }
 
   runner_worker_cache = {

--- a/examples/runner-public/variables.tf
+++ b/examples/runner-public/variables.tf
@@ -22,7 +22,7 @@ variable "gitlab_url" {
   default     = "https://gitlab.com"
 }
 
-variable "registration_token" {
-  description = "Registration token for the runner."
+variable "preregistered_runner_token_ssm_parameter_name" {
+  description = "The name of the SSM parameter to read the preregistered GitLab Runner token from."
   type        = string
 }

--- a/main.tf
+++ b/main.tf
@@ -59,6 +59,7 @@ locals {
       post_install                                                 = var.runner_install.post_install_script
       runners_gitlab_url                                           = var.runner_gitlab.url
       runners_token                                                = var.runner_gitlab.registration_token
+      preregistered_runner_token_ssm_parameter_name = var.runner_gitlab.preregistered_runner_token_ssm_parameter_name
       secure_parameter_store_gitlab_runner_registration_token_name = var.runner_gitlab_registration_token_secure_parameter_store_name
       secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn

--- a/main.tf
+++ b/main.tf
@@ -59,7 +59,7 @@ locals {
       post_install                                                 = var.runner_install.post_install_script
       runners_gitlab_url                                           = var.runner_gitlab.url
       runners_token                                                = var.runner_gitlab.registration_token
-      preregistered_runner_token_ssm_parameter_name = var.runner_gitlab.preregistered_runner_token_ssm_parameter_name
+      preregistered_runner_token_ssm_parameter_name                = var.runner_gitlab.preregistered_runner_token_ssm_parameter_name
       secure_parameter_store_gitlab_runner_registration_token_name = var.runner_gitlab_registration_token_secure_parameter_store_name
       secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -245,7 +245,7 @@ if [[ "${preregistered_runner_token_ssm_parameter_name}" == "" ]]; then
       echo "Token still in use. GitLab Runner not removed from GitLab."
     fi
 
-    EOF
+EOF
 
     chmod a+x /opt/remove_gitlab_registration.sh
     systemctl enable remove-gitlab-registration.service

--- a/template/gitlab-runner.tftpl
+++ b/template/gitlab-runner.tftpl
@@ -17,103 +17,113 @@ sed -i.bak s/__PARENT_TAG__/$PARENT_TAG/g /etc/gitlab-runner/config.toml
 
 ${pre_install_certificates}
 
-# fetch Runner token from SSM and validate it
-json_token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -cr ".Parameters[0].Value" | tr -d '\r\n')
+# TODO remove the "else" block after v8.0.0
+if [[ "${preregistered_runner_token_ssm_parameter_name}" != "" ]]; then
+  # this is the new standard registration method: the runner is already registered in GitLab and the token is stored in SSM
+  preregistered_runner_token=$(aws ssm get-parameter --name "${preregistered_runner_token_ssm_parameter_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
 
-# TODO 2024-03-22: this conversion can be removed as soon as all callers switched to version 7.4.1+
-if [[ ! "$json_token" =~ ^\{.* ]]; then
-  # plain text token -> convert to JSON and store
-  json_token="{\"token\": \"$json_token\", \"usage_counter\": 1}"
+  sed -i.bak s/__REPLACED_BY_USER_DATA__/$preregistered_runner_token/g /etc/gitlab-runner/config.toml
 
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
-
-  echo "GitLab Runner token converted into new JSON format"
+  # TODO after v8.0.0: this logic can be removed. We can insert the token directly into the config.toml
 else
-  # increment the usage_counter as we are using the token now
-  usage_counter=$(echo $json_token | jq -r .usage_counter)
-  usage_counter=$(($usage_counter+1))
-  json_token=$(echo $json_token | jq -c ".usage_counter = $usage_counter")
+    # fetch Runner token from SSM and validate it
+    json_token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -cr ".Parameters[0].Value" | tr -d '\r\n')
 
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
+    # TODO 2024-03-22: this conversion can be removed as soon as all callers switched to version 7.4.1+
+    if [[ ! "$json_token" =~ ^\{.* ]]; then
+      # plain text token -> convert to JSON and store
+      json_token="{\"token\": \"$json_token\", \"usage_counter\": 1}"
 
-  token=$(echo $json_token | jq -r '.token')
-fi
+      aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
 
-valid_token=true
-if [[ "$token" != "null" ]]
-then
-  valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
-  [[ "$valid_token_response" != "200" ]] && valid_token=false
-fi
+      echo "GitLab Runner token converted into new JSON format"
+    else
+      # increment the usage_counter as we are using the token now
+      usage_counter=$(echo $json_token | jq -r .usage_counter)
+      usage_counter=$(($usage_counter+1))
+      json_token=$(echo $json_token | jq -c ".usage_counter = $usage_counter")
 
-if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
-then
-  if [ "${use_new_runner_authentication_gitlab_16}" == "true" ]
-  then
-    runner_type_param=""
-    if [ "${gitlab_runner_type}" = "group" ]; then
-      if [ -z "${gitlab_runner_group_id}" ]; then
-        echo "ERROR: If the runner type is group, you must specify a group_id".
-        exit 1
-      fi
-      runner_type_param='--form group_id=${gitlab_runner_group_id}'
-    elif [ "${gitlab_runner_type}" = "project" ]; then
-      if [ -z "${gitlab_runner_project_id}" ]; then
-        echo "ERROR: If the runner type is project_type, you must specify a project_id".
-        exit 1
-      fi
-      runner_type_param='--form project_id=${gitlab_runner_project_id}'
+      aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
+
+      token=$(echo $json_token | jq -r '.token')
     fi
 
-    # fetch gitlab token from SSM
-    gitlab_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
-
-    response=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/user/runners" \
-      --header "private-token: $gitlab_token" \
-      --form "tag_list=${gitlab_runner_tag_list}" \
-      --form "description=${gitlab_runner_description}" \
-      --form "locked=${gitlab_runner_locked_to_project}" \
-      --form "run_untagged=${gitlab_runner_run_untagged}" \
-      --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
-      --form "runner_type=${gitlab_runner_type}_type" \
-      $runner_type_param \
-      --form "access_level=${gitlab_runner_access_level}")
-
-    token=$(echo $response | jq -r '.token')
-    if [[ "$token" == null ]]
+    valid_token=true
+    if [[ "$token" != "null" ]]
     then
-        message=$(echo $response | jq -r '.message // .error_description')
-        if [[ "$message" != null ]]
-        then
-            echo "ERROR: Couldn't register the Runner. GitLab API call returned $message".
+      valid_token_response=$(curl -s -o /dev/null -w "%%{response_code}" ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners/verify" --form "token=$token" )
+      [[ "$valid_token_response" != "200" ]] && valid_token=false
+    fi
+
+    if [[ "${runners_token}" == "__REPLACED_BY_USER_DATA__" && "$token" == "null" ]] || [[ "$valid_token" == "false" ]]
+    then
+      if [ "${use_new_runner_authentication_gitlab_16}" == "true" ]
+      then
+        runner_type_param=""
+        if [ "${gitlab_runner_type}" = "group" ]; then
+          if [ -z "${gitlab_runner_group_id}" ]; then
+            echo "ERROR: If the runner type is group, you must specify a group_id".
             exit 1
+          fi
+          runner_type_param='--form group_id=${gitlab_runner_group_id}'
+        elif [ "${gitlab_runner_type}" = "project" ]; then
+          if [ -z "${gitlab_runner_project_id}" ]; then
+            echo "ERROR: If the runner type is project_type, you must specify a project_id".
+            exit 1
+          fi
+          runner_type_param='--form project_id=${gitlab_runner_project_id}'
         fi
+
+        # fetch gitlab token from SSM
+        gitlab_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
+
+        response=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/user/runners" \
+          --header "private-token: $gitlab_token" \
+          --form "tag_list=${gitlab_runner_tag_list}" \
+          --form "description=${gitlab_runner_description}" \
+          --form "locked=${gitlab_runner_locked_to_project}" \
+          --form "run_untagged=${gitlab_runner_run_untagged}" \
+          --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
+          --form "runner_type=${gitlab_runner_type}_type" \
+          $runner_type_param \
+          --form "access_level=${gitlab_runner_access_level}")
+
+        token=$(echo $response | jq -r '.token')
+        if [[ "$token" == null ]]
+        then
+            message=$(echo $response | jq -r '.message // .error_description')
+            if [[ "$message" != null ]]
+            then
+                echo "ERROR: Couldn't register the Runner. GitLab API call returned $message".
+                exit 1
+            fi
+        fi
+      else
+        gitlab_runner_registration_token=${gitlab_runner_registration_token}
+
+        # fetch registration token from SSM
+        if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
+        then
+          gitlab_runner_registration_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_runner_registration_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
+        fi
+
+        token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
+        --form "token=$gitlab_runner_registration_token" \
+        --form "tag_list=${gitlab_runner_tag_list}" \
+        --form "description=${gitlab_runner_description}" \
+        --form "locked=${gitlab_runner_locked_to_project}" \
+        --form "run_untagged=${gitlab_runner_run_untagged}" \
+        --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
+        --form "access_level=${gitlab_runner_access_level}" \
+        | jq -r .token)
+      fi
+
+      aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" \
+        --value="{\"token\": \"$token\", \"usage_counter\": 1}" --region "${secure_parameter_store_region}"
     fi
-  else
-    gitlab_runner_registration_token=${gitlab_runner_registration_token}
 
-    # fetch registration token from SSM
-    if [[ "$gitlab_runner_registration_token" == "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__" ]]
-    then
-      gitlab_runner_registration_token=$(aws ssm get-parameter --name "${secure_parameter_store_gitlab_runner_registration_token_name}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameter | .Value")
-    fi
-
-    token=$(curl ${curl_cacert} --request POST -L "${runners_gitlab_url}/api/v4/runners" \
-    --form "token=$gitlab_runner_registration_token" \
-    --form "tag_list=${gitlab_runner_tag_list}" \
-    --form "description=${gitlab_runner_description}" \
-    --form "locked=${gitlab_runner_locked_to_project}" \
-    --form "run_untagged=${gitlab_runner_run_untagged}" \
-    --form "maximum_timeout=${gitlab_runner_maximum_timeout}" \
-    --form "access_level=${gitlab_runner_access_level}" \
-    | jq -r .token)
-  fi
-
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" \
-    --value="{\"token\": \"$token\", \"usage_counter\": 1}" --region "${secure_parameter_store_region}"
+    sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
 fi
-
-sed -i.bak s/__REPLACED_BY_USER_DATA__/$token/g /etc/gitlab-runner/config.toml
 
 if [[ "${use_fleet}" == "true" ]]
 then
@@ -202,43 +212,47 @@ WantedBy=multi-user.target
 
 EOF
 
-cat <<'EOF' > /opt/remove_gitlab_registration.sh
-#!/bin/bash
-json_token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters[0].Value" | tr -d '\r\n')
-deregister_runner=true
+# TODO remove the following block after v8.0.0
+# no longer needed as we use preregistered runners
+if [[ "${preregistered_runner_token_ssm_parameter_name}" == "" ]]; then
+    cat <<'EOF' > /opt/remove_gitlab_registration.sh
+    #!/bin/bash
+    json_token=$(aws ssm get-parameters --names "${secure_parameter_store_runner_token_key}" --with-decryption --region "${secure_parameter_store_region}" | jq -r ".Parameters[0].Value" | tr -d '\r\n')
+    deregister_runner=true
 
-usage_counter=$(echo $json_token | jq -r .usage_counter)
+    usage_counter=$(echo $json_token | jq -r .usage_counter)
 
-# ensure that the token is not in use by another Runner
-if [[ $usage_counter -gt 1 ]]; then
-  deregister_runner=false
-  token="not needed"
-else
-  token=$(echo $json_token | jq -r .token)
+    # ensure that the token is not in use by another Runner
+    if [[ $usage_counter -gt 1 ]]; then
+      deregister_runner=false
+      token="not needed"
+    else
+      token=$(echo $json_token | jq -r .token)
+    fi
+
+    if [[ $deregister_runner == "true" ]]; then
+      echo "Removing Gitlab Runner ..."
+
+      aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="{\"token\": \"null\", \"usage_counter\": 0}" 2>&1
+      curl -sS ${curl_cacert} --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token" 2>&1
+    else
+      usage_counter=$(echo $json_token | jq -r .usage_counter)
+      usage_counter=$(($usage_counter-1))
+      json_token=$(echo $json_token | jq -c ".usage_counter = $usage_counter")
+
+      aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
+
+      echo "Token still in use. GitLab Runner not removed from GitLab."
+    fi
+
+    EOF
+
+    chmod a+x /opt/remove_gitlab_registration.sh
+    systemctl enable remove-gitlab-registration.service
+
+    # start the service. Otherwise the stop action will not be triggered at shutdown.
+    service remove-gitlab-registration start
 fi
-
-if [[ $deregister_runner == "true" ]]; then
-  echo "Removing Gitlab Runner ..."
-
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="{\"token\": \"null\", \"usage_counter\": 0}" 2>&1
-  curl -sS ${curl_cacert} --request DELETE "${runners_gitlab_url}/api/v4/runners" --form "token=$token" 2>&1
-else
-  usage_counter=$(echo $json_token | jq -r .usage_counter)
-  usage_counter=$(($usage_counter-1))
-  json_token=$(echo $json_token | jq -c ".usage_counter = $usage_counter")
-
-  aws ssm put-parameter --overwrite --type SecureString  --name "${secure_parameter_store_runner_token_key}" --region "${secure_parameter_store_region}" --value="$json_token" 2>&1
-
-  echo "Token still in use. GitLab Runner not removed from GitLab."
-fi
-
-EOF
-
-chmod a+x /opt/remove_gitlab_registration.sh
-systemctl enable remove-gitlab-registration.service
-
-# start the service. Otherwise the stop action will not be triggered at shutdown.
-service remove-gitlab-registration start
 
 if ! ( rpm -q gitlab-runner >/dev/null )
 then

--- a/variables.tf
+++ b/variables.tf
@@ -318,6 +318,8 @@ variable "runner_gitlab_registration_config" {
   }
 }
 
+# baee238e-1921-4801-9c3f-79ae1d7b2cbc: we don't have secrets here
+# kics-scan ignore-line
 variable "runner_gitlab" {
   description = <<-EOT
     ca_certificate = Trusted CA certificate bundle (PEM format).

--- a/variables.tf
+++ b/variables.tf
@@ -318,12 +318,12 @@ variable "runner_gitlab_registration_config" {
   }
 }
 
+# baee238e-1921-4801-9c3f-79ae1d7b2cbc: we don't have secrets here
+# kics-scan ignore-block
 variable "runner_gitlab" {
   description = <<-EOT
     ca_certificate = Trusted CA certificate bundle (PEM format).
     certificate = Certificate of the GitLab instance to connect to (PEM format).
-# baee238e-1921-4801-9c3f-79ae1d7b2cbc: we don't have secrets here
-# kics-scan ignore-line
     registration_token = (deprecated, This is replaced by the `registration_token` in `runner_gitlab_registration_config`.) Registration token to use to register the Runner.
     runner_version = Version of the [GitLab Runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases).
     url = URL of the GitLab instance to connect to.

--- a/variables.tf
+++ b/variables.tf
@@ -329,6 +329,7 @@ variable "runner_gitlab" {
     url = URL of the GitLab instance to connect to.
     url_clone = URL of the GitLab instance to clone from. Use only if the agent can’t connect to the GitLab URL.
     access_token_secure_parameter_store_name = (deprecated) The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
+    preregistered_runner_token_ssm_parameter_name = The name of the SSM parameter to read the preregistered GitLab Runner token from.
   EOT
   type = object({
     ca_certificate                                = optional(string, "")

--- a/variables.tf
+++ b/variables.tf
@@ -318,12 +318,12 @@ variable "runner_gitlab_registration_config" {
   }
 }
 
-# baee238e-1921-4801-9c3f-79ae1d7b2cbc: we don't have secrets here
-# kics-scan ignore-line
 variable "runner_gitlab" {
   description = <<-EOT
     ca_certificate = Trusted CA certificate bundle (PEM format).
     certificate = Certificate of the GitLab instance to connect to (PEM format).
+# baee238e-1921-4801-9c3f-79ae1d7b2cbc: we don't have secrets here
+# kics-scan ignore-line
     registration_token = (deprecated, This is replaced by the `registration_token` in `runner_gitlab_registration_config`.) Registration token to use to register the Runner.
     runner_version = Version of the [GitLab Runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases).
     url = URL of the GitLab instance to connect to.

--- a/variables.tf
+++ b/variables.tf
@@ -300,15 +300,15 @@ variable "runner_gitlab_registration_config" {
   description = "(deprecated, repalced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
   type = object({
     registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__") # deprecated, removed in 8.0.0
-    tag_list           = optional(string, "") # deprecated, removed in 8.0.0
-    description        = optional(string, "") # deprecated, removed in 8.0.0
-    type               = optional(string, "") # mandatory if gitlab_runner_version >= 16.0.0 # deprecated, removed in 8.0.0
-    group_id           = optional(string, "") # mandatory if type is group # deprecated, removed in 8.0.0
-    project_id         = optional(string, "") # mandatory if type is project # deprecated, removed in 8.0.0
-    locked_to_project  = optional(string, "") # deprecated, removed in 8.0.0
-    run_untagged       = optional(string, "") # deprecated, removed in 8.0.0
-    maximum_timeout    = optional(string, "") # deprecated, removed in 8.0.0
-    access_level       = optional(string, "not_protected") # this is the only mandatory field calling the GitLab get token for executor operation # deprecated, removed in 8.0.0
+    tag_list           = optional(string, "")                                       # deprecated, removed in 8.0.0
+    description        = optional(string, "")                                       # deprecated, removed in 8.0.0
+    type               = optional(string, "")                                       # mandatory if gitlab_runner_version >= 16.0.0 # deprecated, removed in 8.0.0
+    group_id           = optional(string, "")                                       # mandatory if type is group # deprecated, removed in 8.0.0
+    project_id         = optional(string, "")                                       # mandatory if type is project # deprecated, removed in 8.0.0
+    locked_to_project  = optional(string, "")                                       # deprecated, removed in 8.0.0
+    run_untagged       = optional(string, "")                                       # deprecated, removed in 8.0.0
+    maximum_timeout    = optional(string, "")                                       # deprecated, removed in 8.0.0
+    access_level       = optional(string, "not_protected")                          # this is the only mandatory field calling the GitLab get token for executor operation # deprecated, removed in 8.0.0
   })
 
   default = {}
@@ -329,13 +329,13 @@ variable "runner_gitlab" {
     access_token_secure_parameter_store_name = (deprecated) The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
   EOT
   type = object({
-    ca_certificate                           = optional(string, "")
-    certificate                              = optional(string, "")
-    registration_token                       = optional(string, "__REPLACED_BY_USER_DATA__") # deprecated, removed in 8.0.0
-    runner_version                           = optional(string, "15.8.2")
-    url                                      = optional(string, "")
-    url_clone                                = optional(string, "")
-    access_token_secure_parameter_store_name = optional(string, "gitlab-runner-access-token") # deprecated, removed in 8.0.0
+    ca_certificate                                = optional(string, "")
+    certificate                                   = optional(string, "")
+    registration_token                            = optional(string, "__REPLACED_BY_USER_DATA__") # deprecated, removed in 8.0.0
+    runner_version                                = optional(string, "15.8.2")
+    url                                           = optional(string, "")
+    url_clone                                     = optional(string, "")
+    access_token_secure_parameter_store_name      = optional(string, "gitlab-runner-access-token") # deprecated, removed in 8.0.0
     preregistered_runner_token_ssm_parameter_name = optional(string, "")
   })
 }

--- a/variables.tf
+++ b/variables.tf
@@ -297,7 +297,7 @@ variable "runner_cloudwatch" {
 }
 
 variable "runner_gitlab_registration_config" {
-  description = "(deprecated, repalced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
+  description = "(deprecated, replaced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
   type = object({
     registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__") # deprecated, removed in 8.0.0
     tag_list           = optional(string, "")                                       # deprecated, removed in 8.0.0

--- a/variables.tf
+++ b/variables.tf
@@ -297,18 +297,18 @@ variable "runner_cloudwatch" {
 }
 
 variable "runner_gitlab_registration_config" {
-  description = "Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
+  description = "(deprecated, repalced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) Configuration used to register the Runner. See the README for an example, or reference the examples in the examples directory of this repo. There is also a good GitLab documentation available at: https://docs.gitlab.com/ee/ci/runners/configure_runners.html"
   type = object({
-    registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__")
-    tag_list           = optional(string, "")
-    description        = optional(string, "")
-    type               = optional(string, "") # mandatory if gitlab_runner_version >= 16.0.0
-    group_id           = optional(string, "") # mandatory if type is group
-    project_id         = optional(string, "") # mandatory if type is project
-    locked_to_project  = optional(string, "")
-    run_untagged       = optional(string, "")
-    maximum_timeout    = optional(string, "")
-    access_level       = optional(string, "not_protected") # this is the only mandatory field calling the GitLab get token for executor operation
+    registration_token = optional(string, "__GITLAB_REGISTRATION_TOKEN_FROM_SSM__") # deprecated, removed in 8.0.0
+    tag_list           = optional(string, "") # deprecated, removed in 8.0.0
+    description        = optional(string, "") # deprecated, removed in 8.0.0
+    type               = optional(string, "") # mandatory if gitlab_runner_version >= 16.0.0 # deprecated, removed in 8.0.0
+    group_id           = optional(string, "") # mandatory if type is group # deprecated, removed in 8.0.0
+    project_id         = optional(string, "") # mandatory if type is project # deprecated, removed in 8.0.0
+    locked_to_project  = optional(string, "") # deprecated, removed in 8.0.0
+    run_untagged       = optional(string, "") # deprecated, removed in 8.0.0
+    maximum_timeout    = optional(string, "") # deprecated, removed in 8.0.0
+    access_level       = optional(string, "not_protected") # this is the only mandatory field calling the GitLab get token for executor operation # deprecated, removed in 8.0.0
   })
 
   default = {}
@@ -322,25 +322,26 @@ variable "runner_gitlab" {
   description = <<-EOT
     ca_certificate = Trusted CA certificate bundle (PEM format).
     certificate = Certificate of the GitLab instance to connect to (PEM format).
-    registration_token = Registration token to use to register the Runner. Do not use. This is replaced by the `registration_token` in `runner_gitlab_registration_config`.
+    registration_token = (deprecated, This is replaced by the `registration_token` in `runner_gitlab_registration_config`.) Registration token to use to register the Runner.
     runner_version = Version of the [GitLab Runner](https://gitlab.com/gitlab-org/gitlab-runner/-/releases).
     url = URL of the GitLab instance to connect to.
     url_clone = URL of the GitLab instance to clone from. Use only if the agent can’t connect to the GitLab URL.
-    access_token_secure_parameter_store_name = The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
+    access_token_secure_parameter_store_name = (deprecated) The name of the SSM parameter to read the GitLab access token from. It must have the `api` scope and be pre created.
   EOT
   type = object({
     ca_certificate                           = optional(string, "")
     certificate                              = optional(string, "")
-    registration_token                       = optional(string, "__REPLACED_BY_USER_DATA__")
+    registration_token                       = optional(string, "__REPLACED_BY_USER_DATA__") # deprecated, removed in 8.0.0
     runner_version                           = optional(string, "15.8.2")
     url                                      = optional(string, "")
     url_clone                                = optional(string, "")
-    access_token_secure_parameter_store_name = optional(string, "gitlab-runner-access-token")
+    access_token_secure_parameter_store_name = optional(string, "gitlab-runner-access-token") # deprecated, removed in 8.0.0
+    preregistered_runner_token_ssm_parameter_name = optional(string, "")
   })
 }
 
 variable "runner_gitlab_registration_token_secure_parameter_store_name" {
-  description = "The name of the SSM parameter to read the GitLab Runner registration token from."
+  description = "(deprecated, replaced by runner_gitlab.preregistered_runner_token_ssm_parameter_name) The name of the SSM parameter to read the GitLab Runner registration token from."
   type        = string
   default     = "gitlab-runner-registration-token"
 }


### PR DESCRIPTION
## Description

GitLab announced then [Next GitLab Runner Token Architecture](https://docs.gitlab.com/ee/architecture/blueprints/runner_tokens/index.html#proposal). Runners have to be registered manually.

This PR adds a new import parameter `runner_gitlab.preregistered_runner_token_ssm_parameter_name` holding the name of a SSM parameter (type: `SecuredString`). This parameter contains the GitLab Runner token obtained from GitLab. All other registration methods will still work, but have been marked as deprecated and will be removed with [v8.0.0](https://github.com/cattle-ops/terraform-aws-gitlab-runner/milestone/4) end of the year.

This also solves the problems with Runners removed from GitLab at shutdown, resulting in new Runners not able to start.

Closes #1074 and #1109 

## Verification

- [x] deployed the module using the new registration version. Runner is online.
- [x] deployed the module using the old authentication schema. Runner is online.
