### PR TITLE
fix: increase timeout for EC2 termination lambda

### DIFF
--- a/modules/terminate-agent-hook/main.tf
+++ b/modules/terminate-agent-hook/main.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "terminate_runner_instances" {
   publish          = true
   role             = aws_iam_role.lambda.arn
   runtime          = "python3.11"
-  timeout          = 30
+  timeout          = 90
   kms_key_arn      = var.kms_key_id
 
   tags = var.tags


### PR DESCRIPTION
## Description

Increases the timeout to 90s to give the Lambda function more time to complete. #1149 describes errors in case of big installations (number of EC2 instances).

## Verification

None.
