### PR TITLE
feat: add `pre_get_sources_script` for GitLab Runner 17+

### DIFF
--- a/template/runner-config.tftpl
+++ b/template/runner-config.tftpl
@@ -14,7 +14,9 @@ listen_address = "${prometheus_listen_address}"
   environment = ${runners_environment_vars}
   pre_build_script = ${runners_pre_build_script}
   post_build_script = ${runners_post_build_script}
+  # GitLab Runner < 17, otherwise use pre_get_sources_script
   pre_clone_script = ${runners_pre_clone_script}
+  pre_get_sources_script = ${runners_pre_clone_script}
   request_concurrency = ${runners_request_concurrency}
   output_limit = ${runners_output_limit}
   limit = ${runners_limit}


### PR DESCRIPTION
## Description

Adds the `pre_get_sources_script` (GitLab Runner 17+) parameter which is filled with the value of `pre_clone_script` (GitLab Runner < 17).

The parameter was renamed. Deprecation warnings are shown in the logs of GitLab Runner 16. GitLab Runner 17 simply ignores the parameter and therefor the whole script. This might result in failing pipelines.

## Verification

- [x] use Runner 16 and verify that the script is taken into account
- [x] use Runner 17 and verify that the script is taken into account
- [x] no errors and warnings are shown in the log
