### PR TITLE
feat: make the graceful terminate Lambda timeout configurable

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -92,7 +92,7 @@ locals {
 
   docker_machine_adds_name_tag = signum(sum(local.docker_machine_version_test)) <= 0
 
-  runner_worker_graceful_terminate_timeout_duration = (var.runner_terminate_ec2_lifecycle_timeout_duration == null
+  runner_worker_graceful_terminate_heartbeat_timeout = (var.runner_terminate_ec2_lifecycle_timeout_duration == null
     ? min(7200, tonumber(coalesce(var.runner_gitlab_registration_config.maximum_timeout, 0)) + 300)
   : var.runner_terminate_ec2_lifecycle_timeout_duration)
 }

--- a/main.tf
+++ b/main.tf
@@ -775,12 +775,13 @@ module "terminate_agent_hook" {
   environment                            = var.environment
   asg_arn                                = aws_autoscaling_group.gitlab_runner_instance.arn
   asg_name                               = aws_autoscaling_group.gitlab_runner_instance.name
+  timeout                                = var.runner_terminate_ec2_timeout_duration
   cloudwatch_logging_retention_in_days   = var.runner_cloudwatch.retention_days
   name_iam_objects                       = local.name_iam_objects
   name_docker_machine_runners            = local.runner_tags_merged["Name"]
   role_permissions_boundary              = var.iam_permissions_boundary == "" ? null : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.iam_permissions_boundary}"
   kms_key_id                             = local.kms_key
-  asg_hook_terminating_heartbeat_timeout = local.runner_worker_graceful_terminate_timeout_duration
+  asg_hook_terminating_heartbeat_timeout = local.runner_worker_graceful_terminate_heartbeat_timeout
 
   tags = local.tags
 }

--- a/modules/terminate-agent-hook/main.tf
+++ b/modules/terminate-agent-hook/main.tf
@@ -36,7 +36,7 @@ resource "aws_lambda_function" "terminate_runner_instances" {
   publish          = true
   role             = aws_iam_role.lambda.arn
   runtime          = "python3.11"
-  timeout          = 90
+  timeout          = var.timeout
   kms_key_arn      = var.kms_key_id
 
   tags = var.tags

--- a/modules/terminate-agent-hook/variables.tf
+++ b/modules/terminate-agent-hook/variables.tf
@@ -27,6 +27,12 @@ variable "tags" {
   default     = {}
 }
 
+variable "timeout" {
+  description = "Timeout in seconds for the Lambda function."
+  type        = number
+  default     = 90
+}
+
 variable "role_permissions_boundary" {
   description = "An optional IAM permissions boundary to use when creating IAM roles."
   type        = string

--- a/variables.tf
+++ b/variables.tf
@@ -380,6 +380,12 @@ variable "runner_terraform_timeout_delete_asg" {
   type        = string
 }
 
+variable "runner_terminate_ec2_timeout_duration" {
+  description = "Timeout in seconds for the graceful terminate worker Lambda function."
+  type        = number
+  default     = 90
+}
+
 /*
  * Runner Worker: The process created by the Runner on the host computing platform to run jobs.
  */


### PR DESCRIPTION
## Description

Add `var.runner_terminate_ec2_timeout_duration` with a default of 90 seconds. Makes it possible to configure the timeout in case hundreds of workers are controlled by a single GitLab Runner Agent. Otherwise the Lambda function might fail and does not remove any worker in case the Agent is stopped.

Closes #1149 