### PR TITLE
fix: use correct names for autoscaler policies configuration

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -130,7 +130,7 @@ locals {
       runners_autoscaling = [for config in var.runner_worker_docker_autoscaler_autoscaling_options : {
         for key, value in config :
         # Convert key from snake_case to PascalCase which is the casing for this section.
-        join("", [for subkey in split("_", key) : title(subkey)]) => jsonencode(value) if value != null
+        key => jsonencode(value) if value != null
       }]
   })
 


### PR DESCRIPTION
## Description

PascalCase was used to create the `[[runners.autoscaler.policy]]` which is wrong according to the documentation. This PR fixes the names in the configuration file. `IdleCount` --> `idle_count` 

The worker instances were used once and then terminated. This resulted in a high load of some AWS autoscaling APIs and we got rate limiting. In the end most pipelines failed.

## Verification

Deployed the changes into my environment. The worker machines are reused now.
