### PR TITLE
fix: add `"` to the new `update_interval_*` options of the autoscaler

### DIFF
--- a/template/runner-docker-autoscaler-config.tftpl
+++ b/template/runner-docker-autoscaler-config.tftpl
@@ -3,8 +3,8 @@
     plugin = "fleeting-plugin-aws"
 
     capacity_per_instance = ${runners_capacity_per_instance}
-    update_interval = ${runners_update_interval}
-    update_interval_when_expecting = ${runners_update_interval_when_expecting}
+    update_interval = "${runners_update_interval}"
+    update_interval_when_expecting = "${runners_update_interval_when_expecting}"
 
     max_use_count = ${runners_max_use_count}
     max_instances = ${runners_max_instances}


### PR DESCRIPTION
## Description

The new options `update_interval` and `update_interval_when_expecting` are strings and need a `"` around the value. Otherwise the configuration file has the wrong format and the Agent might not work as expected.

Closes #1176