### PR TITLE
fix: autoscaler asg subnets and add possibility to enable metrics for asg

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -177,6 +177,7 @@ resource "aws_autoscaling_group" "autoscaler" {
   health_check_grace_period = var.runner_worker_docker_autoscaler_asg.health_check_grace_period
   health_check_type         = var.runner_worker_docker_autoscaler_asg.health_check_type
   force_delete              = true
+  enabled_metrics           = var.runner_worker_docker_autoscaler_asg.enabled_metrics
 
   dynamic "tag" {
     for_each = local.tags

--- a/main.tf
+++ b/main.tf
@@ -183,7 +183,7 @@ locals {
 resource "aws_autoscaling_group" "gitlab_runner_instance" {
   # TODO Please explain how `agent_enable_asg_recreation` works
   name                      = var.runner_enable_asg_recreation ? "${aws_launch_template.gitlab_runner_instance.name}-asg" : "${var.environment}-as-group"
-  vpc_zone_identifier       = length(var.runner_worker_docker_machine_instance.subnet_ids) > 0 ? var.runner_worker_docker_machine_instance.subnet_ids : [var.subnet_id]
+  vpc_zone_identifier       = length(var.runner_worker_docker_machine_instance.subnet_ids) > 0 ? var.runner_worker_docker_machine_instance.subnet_ids : length(var.runner_worker_docker_autoscaler_asg.subnet_ids) > 0 ? var.runner_worker_docker_autoscaler_asg.subnet_ids : [var.subnet_id]
   min_size                  = "1"
   max_size                  = "1"
   desired_capacity          = "1"

--- a/variables.tf
+++ b/variables.tf
@@ -670,6 +670,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     subnet_ids = The list of subnet IDs to use for the Runner Worker when the fleet mode is enabled.
     types = The type of instance to use for the Runner Worker. In case of fleet mode, multiple instance types are supported.
     upgrade_strategy = Auto deploy new instances when launch template changes. Can be either 'bluegreen', 'rolling' or 'off'
+    enabled_metrics = List of metrics to collect.
   EOT
   type = object({
     enable_mixed_instances_policy            = optional(bool, false)
@@ -686,6 +687,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     subnet_ids                               = optional(list(string), [])
     types                                    = optional(list(string), ["m5.large"])
     upgrade_strategy                         = optional(string, "rolling")
+    enabled_metrics                          = optional(list(string), [])
     sg_ingresses = optional(list(object({
       description = string
       from_port   = number


### PR DESCRIPTION
## Description
Add the possibility to have multiple subnets for runner manager instance with docker-autoscaler runner type.
Add the variable `enabled_metrics` for docker autoscaler autoscaling group


## Migrations required
No

## Verification
Tested on our side on a production runner.
To enable metrics for docker autoscaler autoscaling group you have to pass a list of metrics, here is my conf
```
runner_worker_docker_autoscaler_asg = {
         ...
         enabled_metrics  = ["GroupMinSize",  "GroupMaxSize", "GroupInServiceInstances", "GroupPendingInstances", 
                                         "GroupStandbyInstances", "GroupTerminatingInstances", "GroupTotalInstances"]
```
