### PR TITLE
chore: set specific file mode for the zipped lambda function to ensure consistent checksums

### DIFF
--- a/modules/terminate-agent-hook/main.tf
+++ b/modules/terminate-agent-hook/main.tf
@@ -9,9 +9,10 @@ locals {
 }
 
 data "archive_file" "terminate_runner_instances_lambda" {
-  type        = "zip"
-  source_file = "${path.module}/lambda/lambda_function.py"
-  output_path = "builds/lambda_function_${local.source_sha256}.zip"
+  type             = "zip"
+  source_file      = "${path.module}/lambda/lambda_function.py"
+  output_path      = "builds/lambda_function_${local.source_sha256}.zip"
+  output_file_mode = "0666"
 }
 
 # tracing functions can be activated by the user


### PR DESCRIPTION
## Description

Hello, this is a follow up of the problems reported in #1171

After digging deeper into the problem, we figured out some more details.

We use Atlantis, running in a Kubernetes cluster, to plan & apply Terraform changes.

The Atlantis PVC is backed by a NFS based backend, therefore not really POSIX compliant. Our guess is that this causes the `source_code_hash` to flap between two different values `STtJd0//CpU4WGQcc2ojckEcEHtCrD8W2fpx9E1TL64` (Which is the result if the file permissions are 0622) and `47DEQpj8HBSa+/TImW+5JCeuQeRkm5NMpJWZG3hSuFU=` (Where I couldn't figure out which exact permissions cause this value to be computed. I tried almost all variantes such as 0644, 0777, etc.)

When running a plan via Atlantis the result sometimes changes within minutes. While doing the research, we found: https://github.com/hashicorp/terraform-provider-archive/issues/34 which describes the problematic behaviour. As you can see, to avoid such issues, a new argument `output_file_mode` was added to the provider, to omit the problem.

After adding `output_file_mode` to all modules during some local tests, the results were always the same. See also: https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file#output_file_mode

I am still really curious, why no one else reported such a behaviour before. It might be the combination of Atlantis / NFS storage as noted above. However, I don't believe that this change will cause any problems with the module.

## Migrations required

No

## Verification

Copy the `lambda_function.py` (Any other test file should work, too) into the same directory as this Terraform code:

```hcl
locals {
  source_sha256 = filesha256("lambda_function.py")
}

data "archive_file" "terminate_runner_instances_lambda" {
  type        = "zip"
  source_file = "lambda_function.py"
  output_path = "builds/lambda_function_${local.source_sha256}.zip"
}

output "lambda_zip_shasum" {
  value = data.archive_file.terminate_runner_instances_lambda.output_base64sha256
}
```

Run apply to see the generated shasum as Terraform output:

```
lambda_zip_shasum = "STtJd0//CpU4WGQcc2ojckEcEHtCrD8W2fpx9E1TL64="
```

Modify the the file permissions: 

```bash
chmod g+w lambda_function.py
```

Run Terraform again:

```hcl
> terraform apply
data.archive_file.terminate_runner_instances_lambda: Reading...
data.archive_file.terminate_runner_instances_lambda: Read complete after 0s [id=e011e457b35f7615551664de5224d2f7f292a697]

Changes to Outputs:
  ~ lambda_zip_shasum = "STtJd0//CpU4WGQcc2ojckEcEHtCrD8W2fpx9E1TL64=" -> "pZAfgYlIKW/ruHEDNtnLDs9h7elRicVa2HhSA6fng9s="

[...]
```

Now repeat the same tests, but add `output_file_mode = "0666"` to the data source:

```
lambda_zip_shasum = "EJcKN1Aif+z+qa8NwFb+dv+O0vBRteYK2/RtTBiULxk="
```

Change the permissions again:


```bash
chmod o+w lambda_function.py
```

Terraform output *doesn't change*:
```
lambda_zip_shasum = "EJcKN1Aif+z+qa8NwFb+dv+O0vBRteYK2/RtTBiULxk="
```
