### PR TITLE
docs: underline that `volume_iops` works only if `runner_worker_docker_machine_fleet.enabled = true`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -823,7 +823,7 @@ variable "runner_worker_docker_machine_instance" {
     types = The type of instance to use for the Runner Worker. In case of fleet mode, multiple instance types are supported.
     volume_type = The type of volume to use for the Runner Worker. `gp2`, `gp3`, `io1` or `io2` are supported.
     volume_throughput = Throughput in MB/s for the volume. Only supported when using `gp3` as `volume_type`.
-    volume_iops = Guaranteed IOPS for the volume. Only supported when using `gp3`, `io1` or `io2` as `volume_type`.
+    volume_iops = Guaranteed IOPS for the volume. Only supported when using `gp3`, `io1` or `io2` as `volume_type`. Works for fleeting only. See `runner_worker_docker_machine_fleet`.
   EOT
   type = object({
     destroy_after_max_builds   = optional(number, 0)


### PR DESCRIPTION
## Description

The `runner_worker_docker_machine_instance.volume_iops` does not work for the docker+machine driver, but works for the fleeting mode which can be enabled via `runner_worker_docker_machine_fleet.enabled = true`. We amend the comment to make that clear.

Closes #1179