### PR TITLE
fix: add missing `tag_specifications` for launch templates

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -97,9 +97,12 @@ resource "aws_launch_template" "this" {
     resource_type = "instance"
     tags          = local.tags
   }
-
   tag_specifications {
     resource_type = "volume"
+    tags          = local.tags
+  }
+  tag_specifications {
+    resource_type = "network-interface"
     tags          = local.tags
   }
 

--- a/main.tf
+++ b/main.tf
@@ -308,6 +308,10 @@ resource "aws_launch_template" "gitlab_runner_instance" {
     resource_type = "volume"
     tags          = local.tags
   }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags          = local.tags
+  }
   dynamic "tag_specifications" {
     for_each = var.runner_instance.spot_price == null || var.runner_instance.spot_price == "" ? [] : ["spot"]
     content {
@@ -409,6 +413,17 @@ resource "aws_launch_template" "fleet_gitlab_runner" {
   tag_specifications {
     resource_type = "volume"
     tags          = local.tags
+  }
+  tag_specifications {
+    resource_type = "network-interface"
+    tags          = local.tags
+  }
+  dynamic "tag_specifications" {
+    for_each = var.runner_worker_docker_machine_instance_spot.enable == false ? [] : ["spot"]
+    content {
+      resource_type = "spot-instances-request"
+      tags          = local.tags
+    }
   }
 
   tags = local.tags

--- a/main.tf
+++ b/main.tf
@@ -418,13 +418,7 @@ resource "aws_launch_template" "fleet_gitlab_runner" {
     resource_type = "network-interface"
     tags          = local.tags
   }
-  dynamic "tag_specifications" {
-    for_each = var.runner_worker_docker_machine_instance_spot.enable == false ? [] : ["spot"]
-    content {
-      resource_type = "spot-instances-request"
-      tags          = local.tags
-    }
-  }
+  # tag_specifications for spot-instances-request do not work. Instance creation fails.
 
   tags = local.tags
 


### PR DESCRIPTION
## Description

Some of the `tag_specifications` were missing and are added in this PR. Leads to more resources being tagged correctly.

Closes #1207 
