### PR TITLE
feat: add variables to specify the AMI ids

### DIFF
--- a/data.tf
+++ b/data.tf
@@ -12,13 +12,14 @@ data "aws_availability_zone" "runners" {
   name = data.aws_subnet.runners.availability_zone
 }
 
-data "aws_ami" "runner" {
-  id = length(var.runner_ami_id) > 0 ? var.runner_ami_id : null
-  owners = length(var.runner_ami_id) > 0 ? var.runner_ami_owners : null
+data "aws_ami" "runner_by_filter" {
+  count = length(var.runner_ami_id) > 0 ? 0 : 1
+
+  owners      = var.runner_ami_owners
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = length(var.runner_ami_id) > 0 ? [] : var.runner_ami_filter
+    for_each = var.runner_ami_filter
 
     content {
       name   = filter.key
@@ -27,15 +28,14 @@ data "aws_ami" "runner" {
   }
 }
 
-data "aws_ami" "docker_machine" {
-  count = var.runner_worker.type == "docker+machine" ? 1 : 0
+data "aws_ami" "docker_machine_by_filter" {
+  count = var.runner_worker.type == "docker+machine" && length(var.runner_worker_docker_machine_ami_id) == 0 ? 1 : 0
 
-  id = length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_id : null
-  owners = length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_owners : null
+  owners      = var.runner_worker_docker_machine_ami_owners
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = length(var.runner_worker_docker_machine_ami_id) > 0 ? [] : var.runner_worker_docker_machine_ami_filter
+    for_each = var.runner_worker_docker_machine_ami_filter
 
     content {
       name   = filter.key
@@ -44,15 +44,14 @@ data "aws_ami" "docker_machine" {
   }
 }
 
-data "aws_ami" "docker-autoscaler" {
-  count = var.runner_worker.type == "docker-autoscaler" ? 1 : 0
+data "aws_ami" "docker_autoscaler_by_filter" {
+  count = var.runner_worker.type == "docker-autoscaler" && length(var.runner_worker_docker_autoscaler_ami_id) == 0 ? 1 : 0
 
-  id = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_id : null
-  owners = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_owners : null
+  owners      = var.runner_worker_docker_autoscaler_ami_owners
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? [] : var.runner_worker_docker_autoscaler_ami_filter
+    for_each = var.runner_worker_docker_autoscaler_ami_filter
 
     content {
       name   = filter.key

--- a/data.tf
+++ b/data.tf
@@ -13,47 +13,50 @@ data "aws_availability_zone" "runners" {
 }
 
 data "aws_ami" "runner" {
+  id = length(var.runner_ami_id) > 0 ? var.runner_ami_id : null
+  owners = length(var.runner_ami_id) > 0 ? var.runner_ami_owners : null
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = var.runner_ami_filter
+    for_each = length(var.runner_ami_id) > 0 ? [] : var.runner_ami_filter
+
     content {
       name   = filter.key
       values = filter.value
     }
   }
-
-  owners = var.runner_ami_owners
 }
 
-data "aws_ami" "docker-machine" {
+data "aws_ami" "docker_machine" {
   count = var.runner_worker.type == "docker+machine" ? 1 : 0
 
+  id = length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_id : null
+  owners = length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_owners : null
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = var.runner_worker_docker_machine_ami_filter
+    for_each = length(var.runner_worker_docker_machine_ami_id) > 0 ? [] : var.runner_worker_docker_machine_ami_filter
+
     content {
       name   = filter.key
       values = filter.value
     }
   }
-
-  owners = var.runner_worker_docker_machine_ami_owners
 }
 
 data "aws_ami" "docker-autoscaler" {
   count = var.runner_worker.type == "docker-autoscaler" ? 1 : 0
 
+  id = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_id : null
+  owners = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_owners : null
   most_recent = "true"
 
   dynamic "filter" {
-    for_each = var.runner_worker_docker_autoscaler_ami_filter
+    for_each = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? [] : var.runner_worker_docker_autoscaler_ami_filter
+
     content {
       name   = filter.key
       values = filter.value
     }
   }
-
-  owners = var.runner_worker_docker_autoscaler_ami_owners
 }

--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -62,7 +62,7 @@ resource "aws_launch_template" "this" {
 
   name          = "${local.name_runner_agent_instance}-worker-launch-template"
   user_data     = base64gzip(var.runner_worker_docker_autoscaler_instance.start_script)
-  image_id      = data.aws_ami.docker-autoscaler[0].id
+  image_id      = length(var.runner_worker_docker_autoscaler_ami_id) > 0 ? var.runner_worker_docker_autoscaler_ami_id : data.aws_ami.docker_autoscaler_by_filter[0].id
   instance_type = var.runner_worker_docker_autoscaler_asg.types[0]
   key_name      = aws_key_pair.autoscaler[0].key_name
   ebs_optimized = var.runner_worker_docker_autoscaler_instance.ebs_optimized

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ locals {
       runners_iam_instance_profile_name = var.runner_worker_docker_machine_role.profile_name
       runners_root_size                 = var.runner_worker_docker_machine_instance.root_size
       runners_volume_type               = var.runner_worker_docker_machine_instance.volume_type
-      runners_ami                       = var.runner_worker.type == "docker+machine" ? data.aws_ami.docker-machine[0].id : ""
+      runners_ami                       = var.runner_worker.type == "docker+machine" ? data.aws_ami.docker_machine[0].id : ""
       use_fleet                         = var.runner_worker_docker_machine_fleet.enable
       launch_template                   = var.runner_worker_docker_machine_fleet.enable == true ? aws_launch_template.fleet_gitlab_runner[0].name : ""
       docker_machine_options            = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
@@ -376,7 +376,7 @@ resource "aws_launch_template" "fleet_gitlab_runner" {
   name_prefix = "${local.name_runner_agent_instance}-worker-"
 
   key_name               = aws_key_pair.fleet[0].key_name
-  image_id               = data.aws_ami.docker-machine[0].id
+  image_id               = data.aws_ami.docker_machine[0].id
   user_data              = base64gzip(var.runner_worker_docker_machine_instance.start_script)
   instance_type          = var.runner_worker_docker_machine_instance.types[0] # it will be override by the fleet
   update_default_version = true

--- a/main.tf
+++ b/main.tf
@@ -113,7 +113,7 @@ locals {
       runners_iam_instance_profile_name = var.runner_worker_docker_machine_role.profile_name
       runners_root_size                 = var.runner_worker_docker_machine_instance.root_size
       runners_volume_type               = var.runner_worker_docker_machine_instance.volume_type
-      runners_ami                       = var.runner_worker.type == "docker+machine" ? data.aws_ami.docker_machine[0].id : ""
+      runners_ami                       = var.runner_worker.type == "docker+machine" ? (length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_id : data.aws_ami.docker_machine_by_filter[0].id) : ""
       use_fleet                         = var.runner_worker_docker_machine_fleet.enable
       launch_template                   = var.runner_worker_docker_machine_fleet.enable == true ? aws_launch_template.fleet_gitlab_runner[0].name : ""
       docker_machine_options            = length(local.docker_machine_options_string) == 1 ? "" : local.docker_machine_options_string
@@ -258,7 +258,7 @@ resource "aws_launch_template" "gitlab_runner_instance" {
   # checkov:skip=CKV_AWS_79:User can decide to enable Metadata service V2. V2 is the default.
   name_prefix = "${local.name_runner_agent_instance}-"
 
-  image_id               = data.aws_ami.runner.id
+  image_id               = length(var.runner_ami_id) > 0 ? var.runner_ami_id : data.aws_ami.runner_by_filter[0].id
   user_data              = base64gzip(local.template_user_data)
   instance_type          = var.runner_instance.type
   update_default_version = true
@@ -376,7 +376,7 @@ resource "aws_launch_template" "fleet_gitlab_runner" {
   name_prefix = "${local.name_runner_agent_instance}-worker-"
 
   key_name               = aws_key_pair.fleet[0].key_name
-  image_id               = data.aws_ami.docker_machine[0].id
+  image_id               = length(var.runner_worker_docker_machine_ami_id) > 0 ? var.runner_worker_docker_machine_ami_id : data.aws_ami.docker_machine_by_filter[0].id
   user_data              = base64gzip(var.runner_worker_docker_machine_instance.start_script)
   instance_type          = var.runner_worker_docker_machine_instance.types[0] # it will be override by the fleet
   update_default_version = true

--- a/variables.tf
+++ b/variables.tf
@@ -150,9 +150,9 @@ variable "runner_ami_owners" {
 }
 
 variable "runner_ami_id" {
-    description = "The AMI ID of the Runner instance."
-    type        = string
-    default     = ""
+  description = "The AMI ID of the Runner instance."
+  type        = string
+  default     = ""
 }
 
 variable "runner_networking" {
@@ -794,8 +794,8 @@ variable "runner_worker_docker_machine_ami_owners" {
 
 variable "runner_worker_docker_machine_ami_id" {
   description = "The ID of the AMI to use for the Runner Worker (docker-machine)."
-    type        = string
-  default = ""
+  type        = string
+  default     = ""
 }
 
 variable "runner_worker_docker_autoscaler_ami_filter" {

--- a/variables.tf
+++ b/variables.tf
@@ -149,6 +149,12 @@ variable "runner_ami_owners" {
   default     = ["amazon"]
 }
 
+variable "runner_ami_id" {
+    description = "The AMI ID of the Runner instance."
+    type        = string
+    default     = ""
+}
+
 variable "runner_networking" {
   description = <<-EOT
     allow_incoming_ping = Allow ICMP Ping to the Runner. Specify `allow_incoming_ping_security_group_ids` too!
@@ -770,16 +776,7 @@ variable "runner_worker_docker_machine_security_group_description" {
 }
 
 variable "runner_worker_docker_machine_ami_filter" {
-  description = "List of maps used to create the AMI filter for the Runner Worker."
-  type        = map(list(string))
-
-  default = {
-    name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
-  }
-}
-
-variable "runner_worker_docker_autoscaler_ami_filter" {
-  description = "List of maps used to create the AMI filter for the Runner Worker."
+  description = "List of maps used to create the AMI filter for the Runner Worker (docker-machine)."
   type        = map(list(string))
 
   default = {
@@ -788,19 +785,40 @@ variable "runner_worker_docker_autoscaler_ami_filter" {
 }
 
 variable "runner_worker_docker_machine_ami_owners" {
-  description = "The list of owners used to select the AMI of the Runner Worker."
+  description = "The list of owners used to select the AMI of the Runner Worker (docker-machine)."
   type        = list(string)
 
   # Canonical
   default = ["099720109477"]
 }
 
+variable "runner_worker_docker_machine_ami_id" {
+  description = "The ID of the AMI to use for the Runner Worker (docker-machine)."
+    type        = string
+  default = ""
+}
+
+variable "runner_worker_docker_autoscaler_ami_filter" {
+  description = "List of maps used to create the AMI filter for the Runner Worker (autoscaler)."
+  type        = map(list(string))
+
+  default = {
+    name = ["ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*"]
+  }
+}
+
 variable "runner_worker_docker_autoscaler_ami_owners" {
-  description = "The list of owners used to select the AMI of the Runner Worker."
+  description = "The list of owners used to select the AMI of the Runner Worker (autoscaler)."
   type        = list(string)
 
   # Canonical
   default = ["099720109477"]
+}
+
+variable "runner_worker_docker_autoscaler_ami_id" {
+  description = "The ID of the AMI to use for the Runner Worker (autoscaler)."
+  type        = string
+  default     = ""
 }
 
 variable "runner_worker_docker_machine_instance" {


### PR DESCRIPTION
## Description

At the moment the latest AMI is read at deploy time. But to get an immutable infrastructure we have to fix the AMI. This PR adds variables to set the AMI id.