### PR TITLE
fix: do not create security group rules for `docker+machine` if `docker-autoscaler` selected

### DIFF
--- a/docker_machine_security_group.tf
+++ b/docker_machine_security_group.tf
@@ -2,6 +2,9 @@
 locals {
   # Only include runner security group id and additional if ping is enabled
   security_groups_ping = var.runner_networking.allow_incoming_ping && length(var.runner_networking.allow_incoming_ping_security_group_ids) > 0 ? concat(var.runner_networking.allow_incoming_ping_security_group_ids, [aws_security_group.runner.id]) : []
+
+  ingress_worker_docker_machine = var.runner_worker.type == "docker+machine" ? var.runner_worker_ingress_rules : {}
+  egress_worker_docker_machine = var.runner_worker.type == "docker+machine" ? var.runner_worker_egress_rules : {}
 }
 
 resource "aws_security_group" "docker_machine" {
@@ -21,7 +24,7 @@ resource "aws_security_group" "docker_machine" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "docker_machine" {
-  for_each = var.runner_worker_ingress_rules
+  for_each = var.runner_worker.type == "docker+machine" ? var.runner_worker_ingress_rules : {}
 
   security_group_id = aws_security_group.docker_machine[0].id
 
@@ -39,7 +42,7 @@ resource "aws_vpc_security_group_ingress_rule" "docker_machine" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "docker_machine" {
-  for_each = var.runner_worker_egress_rules
+  for_each = var.runner_worker.type == "docker+machine" ? var.runner_worker_egress_rules : {}
 
   security_group_id = aws_security_group.docker_machine[0].id
 

--- a/docker_machine_security_group.tf
+++ b/docker_machine_security_group.tf
@@ -2,9 +2,6 @@
 locals {
   # Only include runner security group id and additional if ping is enabled
   security_groups_ping = var.runner_networking.allow_incoming_ping && length(var.runner_networking.allow_incoming_ping_security_group_ids) > 0 ? concat(var.runner_networking.allow_incoming_ping_security_group_ids, [aws_security_group.runner.id]) : []
-
-  ingress_worker_docker_machine = var.runner_worker.type == "docker+machine" ? var.runner_worker_ingress_rules : {}
-  egress_worker_docker_machine = var.runner_worker.type == "docker+machine" ? var.runner_worker_egress_rules : {}
 }
 
 resource "aws_security_group" "docker_machine" {


### PR DESCRIPTION
## Description

The `runner_worker_ingress_rules` and `runner_worker_egress_rules` have to be attached to the correct security group. At the moment the module always attaches the rules to the docker machine security group which does not exist when `docker-autoscaler` is used.
