### PR TITLE
docs: add `max_jobs` to docker-autoscaler example

### DIFF
--- a/examples/runner-fleeting-plugin/main.tf
+++ b/examples/runner-fleeting-plugin/main.tf
@@ -72,8 +72,8 @@ module "runner" {
   }
 
   runner_worker = {
-    type       = "docker-autoscaler"
-    max_jobs   = 10
+    type     = "docker-autoscaler"
+    max_jobs = 10
   }
 
   runner_worker_gitlab_pipeline = {

--- a/examples/runner-fleeting-plugin/main.tf
+++ b/examples/runner-fleeting-plugin/main.tf
@@ -72,7 +72,8 @@ module "runner" {
   }
 
   runner_worker = {
-    type = "docker-autoscaler"
+    type       = "docker-autoscaler"
+    max_jobs   = 10
   }
 
   runner_worker_gitlab_pipeline = {


### PR DESCRIPTION
Otherwise it deploys unusable asg with max=0
