### PR TITLE
fix: allow terminate Lambda to access kms key

### DIFF
--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -36,6 +36,14 @@ resource "aws_iam_role" "lambda" {
 # This IAM policy is used by the Lambda function.
 data "aws_iam_policy_document" "lambda" {
   # checkov:skip=CKV_AWS_111:Write access is limited to the resources needed
+  statement {
+    sid = "allow kms access"
+    actions = [
+      "kms:Decrypt", # to decrypt the Lambda environment variables
+    ]
+    resources = [var.kms_key_id]
+    effect    = "Allow"
+  }
 
   # Permit the function to get a list of instances
   statement {


### PR DESCRIPTION
## Description

Just noticed that the termination Lambdas do no longer start. Error message is

```
Calling the invoke API action failed with this message: Lambda was unable to decrypt the environment variables
because KMS access was denied. Please check the function's KMS key settings. KMS Exception:
AccessDeniedExceptionKMS Message: User: <arn here> is not authorized to perform: kms:Decrypt on resource:
<arn here> because no identity-based policy allows the kms:Decrypt action (Service: Kms, Status Code: 400,
Request ID: <request id here>)
```

This PR adds the `kms:Decrypt` action to the Lambda role allowing the Lambda function to decode the environment variables.