### PR TITLE
chore: update the terminate-agent-hook lambda to Python 3.13 with Arm/Graviton2

### DIFF
--- a/modules/terminate-agent-hook/main.tf
+++ b/modules/terminate-agent-hook/main.tf
@@ -51,7 +51,7 @@ resource "aws_lambda_function" "terminate_runner_instances" {
   # checkov:skip=CKV_AWS_115:We do not assign a reserved concurrency as this function can't be called by users
   # checkov:skip=CKV_AWS_116:We should think about having a dead letter queue for this lambda
   # checkov:skip=CKV_AWS_272:Code signing would be a nice enhancement, but I guess we can live without it here
-  architectures    = ["x86_64"]
+  architectures    = ["arm64"]
   description      = "Lifecycle hook for terminating GitLab runner agent instances"
   filename         = data.archive_file.terminate_runner_instances_lambda.output_path
   source_code_hash = data.archive_file.terminate_runner_instances_lambda.output_base64sha256
@@ -61,7 +61,7 @@ resource "aws_lambda_function" "terminate_runner_instances" {
   package_type     = "Zip"
   publish          = true
   role             = aws_iam_role.lambda.arn
-  runtime          = "python3.11"
+  runtime          = "python3.13"
   timeout          = var.timeout
   kms_key_arn      = var.kms_key_id
 

--- a/modules/terminate-agent-hook/versions.tf
+++ b/modules/terminate-agent-hook/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 4.0.0"
+      version = ">= 5.78"
       source  = "hashicorp/aws"
     }
   }

--- a/modules/terminate-agent-hook/versions.tf
+++ b/modules/terminate-agent-hook/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     aws = {
-      version = ">= 5.78"
+      version = ">= 5.76"
       source  = "hashicorp/aws"
     }
   }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.78"
+      version = ">= 5.76"
     }
     local = {
       source  = "hashicorp/local"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.26"
+      version = ">= 5.78"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Description

This pull request updates the `terminate-agent-hook` Lambda function to use Python 3.13 and the Arm64 architecture (Graviton2). Lambda functions powered by Graviton2 are designed to deliver up to 19% better performance at 20% lower cost, improving both efficiency and cost-effectiveness.

The change also updates the required AWS provider version to `>= 5.76` to ensure compatibility with the latest AWS resources and services.