### PR TITLE
Use current partition instead of assuming `aws`

### DIFF
--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -189,5 +189,5 @@ resource "aws_iam_role_policy_attachment" "spot_request_housekeeping" {
 
 resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access_execution_role" {
   role       = aws_iam_role.lambda.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }


### PR DESCRIPTION
## Description

Don't hardcode the aws partition

See https://github.com/cattle-ops/terraform-aws-gitlab-runner/issues/1273

Note: The whole PR is used as commit message.

## Migrations required

No

## Verification

Please mention how you test the changes.
