### PR TITLE
feat: add option to suspend process AZRebalance for docker autoscaler as recommended

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -79,6 +79,7 @@ resource "aws_autoscaling_group" "autoscaler" {
   name                  = "${local.name_runner_agent_instance}-asg"
   capacity_rebalance    = false
   protect_from_scale_in = true
+  suspended_processes   = var.runner_worker_docker_autoscaler_asg.suspended_processes
 
   dynamic "launch_template" {
     for_each = var.runner_worker_docker_autoscaler_asg.enable_mixed_instances_policy ? [] : [1]

--- a/variables.tf
+++ b/variables.tf
@@ -806,6 +806,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     default_instance_type = Default instance type for the launch template
     types = The type of instance to use for the Runner Worker. In case of fleet mode, multiple instance types are supported.
     upgrade_strategy = Auto deploy new instances when launch template changes. Can be either 'bluegreen', 'rolling' or 'off'.
+    suspended_processes = List of processes to suspend for the Auto Scaling Group.
     instance_requirements = Override the instance type in the Launch Template with instance types that satisfy the requirements.
   EOT
   type = object({
@@ -823,6 +824,7 @@ variable "runner_worker_docker_autoscaler_asg" {
     default_instance_type                    = optional(string, "m5.large")
     types                                    = optional(list(string), [])
     upgrade_strategy                         = optional(string, "rolling")
+    suspended_processes                      = optional(list(string), [])
     instance_requirements = optional(list(object({
       allowed_instance_types = optional(list(string), [])
       cpu_manufacturers      = optional(list(string), [])


### PR DESCRIPTION
## Description

Add the option to suspend processes. As indicated in the autoscaler doc AZRebalance should be suspended https://gitlab.com/gitlab-org/fleeting/plugins/aws#autoscaling-group-setup

## Migrations required

NO - I just added the option but I do not enforce it

## Verification

Tested with our prod runners.
