### PR TITLE
fix: condition on the creation of the kms key

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -388,6 +388,7 @@ module "terminate_agent_hook" {
   name_iam_objects                       = local.name_iam_objects
   name_docker_machine_runners            = local.runner_tags_merged["Name"]
   role_permissions_boundary              = var.iam_permissions_boundary == "" ? null : "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:policy/${var.iam_permissions_boundary}"
+  enable_managed_kms_key                 = var.enable_managed_kms_key
   kms_key_id                             = local.kms_key_arn
   asg_hook_terminating_heartbeat_timeout = local.runner_worker_graceful_terminate_heartbeat_timeout
   environment_variables                  = var.runner_terminate_ec2_environment_variables

--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -189,5 +189,6 @@ resource "aws_iam_role_policy_attachment" "spot_request_housekeeping" {
 
 resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access_execution_role" {
   role       = aws_iam_role.lambda.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+
 }

--- a/modules/terminate-agent-hook/iam.tf
+++ b/modules/terminate-agent-hook/iam.tf
@@ -33,14 +33,14 @@ resource "aws_iam_role" "lambda" {
 }
 
 resource "aws_iam_role_policy_attachment" "lambda_kms" {
-  count = var.kms_key_id != "" ? 1 : 0
+  count = !var.enable_managed_kms_key ? 1 : 0
 
   role       = aws_iam_role.lambda.name
   policy_arn = aws_iam_policy.lambda_kms[0].arn
 }
 
 resource "aws_iam_policy" "lambda_kms" {
-  count = var.kms_key_id != "" ? 1 : 0
+  count = !var.enable_managed_kms_key ? 1 : 0
 
   name   = "${var.name_iam_objects}-${var.name}-lambda-kms"
   path   = "/"
@@ -50,7 +50,7 @@ resource "aws_iam_policy" "lambda_kms" {
 }
 
 data "aws_iam_policy_document" "kms_key" {
-  count = var.kms_key_id != "" ? 1 : 0
+  count = !var.enable_managed_kms_key ? 1 : 0
 
   # checkov:skip=CKV_AWS_111:Write access is limited to the resources needed
   statement {
@@ -189,5 +189,5 @@ resource "aws_iam_role_policy_attachment" "spot_request_housekeeping" {
 
 resource "aws_iam_role_policy_attachment" "aws_lambda_vpc_access_execution_role" {
   role       = aws_iam_role.lambda.name
-  policy_arn = "arn:${data.aws_partition.current.partition}:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole"
 }

--- a/modules/terminate-agent-hook/variables.tf
+++ b/modules/terminate-agent-hook/variables.tf
@@ -56,6 +56,12 @@ variable "name_docker_machine_runners" {
   type        = string
 }
 
+variable "enable_managed_kms_key" {
+  description = "Let the module manage a KMS key. Be-aware of the costs of an custom key. Do not specify a `kms_key_id` when `enable_kms` is set to `true`."
+  type        = bool
+  default     = false
+}
+
 variable "kms_key_id" {
   description = "(optional) KMS key id to encrypt the resources, e.g. logs, lambda environment variables, ..."
   type        = string


### PR DESCRIPTION
## Description

this PR fixes #1278 

Note: The whole PR is used as commit message.

## Migrations required

No

## Verification

I did deploy this module with both options, i.e. enable_managed_kms_key = true and enable_managed_kms_key = false to validate the fix
