### PR TITLE
fix: allow HTTP egress traffic to all destinations

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -937,6 +937,20 @@ variable "runner_worker_egress_rules" {
       protocol        = "tcp"
       description     = "Allow HTTPS egress traffic to all destinations (IPv6)"
     },
+    allow_http_ipv4 = {
+      cidr_block  = "0.0.0.0/0"
+      from_port   = 80
+      to_port     = 80
+      protocol    = "tcp"
+      description = "Allow HTTP egress traffic to all destinations (IPv4)"
+    },
+    allow_http_ipv6 = {
+      ipv6_cidr_block = "::/0"
+      from_port       = 80
+      to_port         = 80
+      protocol        = "tcp"
+      description     = "Allow HTTP egress traffic to all destinations (IPv6)"
+    },
     allow_ssh_ipv4 = {
       cidr_block  = "0.0.0.0/0"
       from_port   = 22


### PR DESCRIPTION
## Description

Allow HTTP (port 80) traffic by default to allow commonly-used resources to be accessible from the `docker-autoscaler` runner workers.

Fix #1302.

## Migrations required

No

## Verification

See #1302 for test cases.
