### PR TITLE
fix(docker-autoscaler): handle scaling properly when capacity_per_instance > 1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -133,7 +133,7 @@ locals {
       runners_name                   = var.runner_instance.name
       runners_token                  = var.runner_gitlab.registration_token
       runners_executor               = var.runner_worker.type
-      runners_limit                  = var.runner_worker.max_jobs
+      runners_limit                  = var.runner_worker.type == "docker-autoscaler" ? var.runner_worker.max_jobs * var.runner_worker_docker_autoscaler.capacity_per_instance : var.runner_worker.max_jobs
       runners_concurrent             = var.runner_manager.maximum_concurrent_jobs
       runners_environment_vars       = jsonencode(var.runner_worker.environment_variables)
       runners_pre_build_script       = var.runner_worker_gitlab_pipeline.pre_build_script


### PR DESCRIPTION
## Summary
This PR fixes a critical bug in the docker-autoscaler configuration where the runner's job limit doesn't account for `capacity_per_instance`, causing incorrect scaling behavior.

## Problem
When using `docker-autoscaler` with `capacity_per_instance > 1`, the module sets the runner's job limit (`limit` field in config.toml) to `max_jobs` without multiplying by `capacity_per_instance`. This causes the GitLab Runner to miscalculate the number of instances needed.

### Example scenario:
- `max_jobs = 25` (intended max instances)
- `capacity_per_instance = 3` (jobs per instance)
- 50 jobs are queued

**Current behavior:**
- Runner job limit = 25
- Runner calculates: ceil(25 ÷ 3) = 9 instances max
- Only 9 instances are created, leaving jobs queued

**Expected behavior:**
- Runner job limit = 75 (25 × 3)
- Runner calculates: ceil(50 ÷ 3) = 17 instances
- Proper scaling up to 25 instances as configured

## Solution
The fix multiplies `max_jobs` by `capacity_per_instance` when setting `runners_limit` for docker-autoscaler type runners.

```hcl
runners_limit = var.runner_worker.type == "docker-autoscaler" ? 
                var.runner_worker.max_jobs * var.runner_worker_docker_autoscaler.capacity_per_instance : 
                var.runner_worker.max_jobs
```

## Testing
Tested with:
- `max_jobs = 25`
- `capacity_per_instance = 3`
- Verified the runner config correctly shows `limit = 75`
- Confirmed ASG can now scale beyond 9 instances

## Breaking Changes
None. This only affects docker-autoscaler configurations with `capacity_per_instance > 1`.

Fixes incorrect autoscaling behavior reported in production environments.