### PR TITLE
chore: update instance-docker-autoscaler-policy

### DIFF
--- a/policies/instance-docker-autoscaler-policy.json
+++ b/policies/instance-docker-autoscaler-policy.json
@@ -13,7 +13,8 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:DescribeAutoScalingGroups",
-                "ec2:DescribeInstances"
+                "ec2:DescribeInstances",
+                "ec2:DescribeSpotInstanceRequests"
             ],
             "Resource": "*"
         },


### PR DESCRIPTION
Updates the instance docker autoscaler policy to match the new recommended iam policy according to the v1.1.0 aws fleeting plugin https://gitlab.com/gitlab-org/fleeting/plugins/aws/-/blob/ed4fb9847d2a83fa05747d40c019f0e6c7b9ebd7/README.md#recommended-iam-policy

## Description

Adds the required iam permissions for the new v1.1.0 version of the gitlab aws fleeting plugin

Note: The whole PR is used as commit message.

## Migrations required

Yes or No - If yes please describe the migration. For bigger changes please provide a migration script.

## Verification

Please mention how you test the changes.
