### PR TITLE
chore(deps): update to Terraform AWS provider 6.0.0+

### DIFF
--- a/docker_autoscaler_policy.tf
+++ b/docker_autoscaler_policy.tf
@@ -16,7 +16,7 @@ resource "aws_iam_policy" "instance_docker_autoscaler_policy" {
   # see https://gitlab.com/gitlab-org/fleeting/plugins/aws#recommended-iam-policy for needed policies
   policy = templatefile("${path.module}/policies/instance-docker-autoscaler-policy.json",
     {
-      aws_region          = data.aws_region.current.name
+      aws_region          = data.aws_region.current.region
       partition           = data.aws_partition.current.partition
       autoscaler_asg_arn  = aws_autoscaling_group.autoscaler[0].arn
       autoscaler_asg_name = aws_autoscaling_group.autoscaler[0].name

--- a/docker_machine.tf
+++ b/docker_machine.tf
@@ -6,7 +6,7 @@ locals {
       runners_max_builds     = local.runners_max_builds_string
       docker_machine_name    = format("%s-%s", local.runner_tags_merged["Name"], "%s") # %s is always needed
       runners_instance_types = var.runner_worker_docker_machine_instance.types
-      aws_region             = data.aws_region.current.name
+      aws_region             = data.aws_region.current.region
       runners_aws_zone       = data.aws_availability_zone.runners.name_suffix
       runners_userdata       = var.runner_worker_docker_machine_instance.start_script
 

--- a/kms.tf
+++ b/kms.tf
@@ -8,7 +8,7 @@ resource "aws_kms_key" "default" {
   policy = templatefile("${path.module}/policies/kms-policy.json",
     {
       partition  = data.aws_partition.current.partition
-      aws_region = data.aws_region.current.name
+      aws_region = data.aws_region.current.region
       account_id = data.aws_caller_identity.current.account_id
     }
   )

--- a/main.tf
+++ b/main.tf
@@ -55,7 +55,7 @@ locals {
 
   template_gitlab_runner = templatefile("${path.module}/template/gitlab-runner.tftpl",
     {
-      aws_region                                                   = data.aws_region.current.name
+      aws_region                                                   = data.aws_region.current.region
       gitlab_runner_version                                        = var.runner_gitlab.runner_version
       docker_machine_version                                       = var.runner_install.docker_machine_version
       docker_machine_download_url                                  = var.runner_install.docker_machine_download_url
@@ -74,7 +74,7 @@ locals {
       secure_parameter_store_runner_token_key                      = local.secure_parameter_store_runner_token_key
       secure_parameter_store_runner_sentry_dsn                     = local.secure_parameter_store_runner_sentry_dsn
       secure_parameter_store_gitlab_token_name                     = var.runner_gitlab.access_token_secure_parameter_store_name
-      secure_parameter_store_region                                = data.aws_region.current.name
+      secure_parameter_store_region                                = data.aws_region.current.region
       gitlab_runner_registration_token                             = var.runner_gitlab_registration_config.registration_token
       gitlab_runner_description                                    = var.runner_gitlab_registration_config["description"]
       gitlab_runner_tag_list                                       = var.runner_gitlab_registration_config["tag_list"]
@@ -120,7 +120,7 @@ locals {
 
   template_runner_config = templatefile("${path.module}/template/runner-config.tftpl",
     {
-      aws_region       = data.aws_region.current.name
+      aws_region       = data.aws_region.current.region
       gitlab_url       = var.runner_gitlab.url
       gitlab_clone_url = var.runner_gitlab.url_clone
       tls_ca_file      = length(var.runner_gitlab.certificate) > 0 ? "tls-ca-file=\"/etc/gitlab-runner/certs/gitlab.crt\"" : ""

--- a/runner_policy.tf
+++ b/runner_policy.tf
@@ -124,14 +124,14 @@ data "aws_iam_policy_document" "ssm" {
           var.runner_gitlab.preregistered_runner_token_ssm_parameter_name,
           aws_ssm_parameter.runner_registration_token.name
         ]
-      ) : "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(name, "/")}"
+      ) : "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(name, "/")}"
     ]
   }
 
   statement {
     actions = ["ssm:PutParameter"]
     resources = [
-      "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(aws_ssm_parameter.runner_registration_token.name, "/")}"
+      "arn:${data.aws_partition.current.partition}:ssm:${data.aws_region.current.region}:${data.aws_caller_identity.current.account_id}:parameter/${trimprefix(aws_ssm_parameter.runner_registration_token.name, "/")}"
     ]
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.76"
+      version = ">= 6.0.0"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
## Description

Upgrades the module to `hashicorp/aws >= 6.0.0`. The version is out for 3+ months and we can fix a deprecation warning for the `aws_region` datasource.

`The attribute "name" is deprecated. Refer to the provider documentation for details.`

Fixes #1295 


