### PR TITLE
fix: add missing policies for the autoscaler

### DIFF
--- a/policies/instance-docker-autoscaler-policy.json
+++ b/policies/instance-docker-autoscaler-policy.json
@@ -5,7 +5,9 @@
             "Effect": "Allow",
             "Action": [
                 "autoscaling:SetDesiredCapacity",
-                "autoscaling:TerminateInstanceInAutoScalingGroup"
+                "autoscaling:TerminateInstanceInAutoScalingGroup",
+                "autoscaling:CompleteLifecycleAction",
+                "autoscaling:DescribeLifecycleHooks"
             ],
             "Resource": "${autoscaler_asg_arn}"
         },


### PR DESCRIPTION
## Description

The policies `autoscaling:CompleteLifecycleAction` and `autoscaling:DescribeLifecycleHooks` were missing for the autoscaler. This PR adds them.

Relates to #1314


