### PR TITLE
fix: send spot_instance_pools only for the lowest-price allocation strategy 

### DIFF
--- a/docker_autoscaler.tf
+++ b/docker_autoscaler.tf
@@ -101,7 +101,7 @@ resource "aws_autoscaling_group" "autoscaler" {
         on_demand_base_capacity                  = var.runner_worker_docker_autoscaler_asg.on_demand_base_capacity
         on_demand_percentage_above_base_capacity = var.runner_worker_docker_autoscaler_asg.on_demand_percentage_above_base_capacity
         spot_allocation_strategy                 = var.runner_worker_docker_autoscaler_asg.spot_allocation_strategy
-        spot_instance_pools                      = var.runner_worker_docker_autoscaler_asg.spot_instance_pools
+        spot_instance_pools                      = var.runner_worker_docker_autoscaler_asg.spot_allocation_strategy == "lowest-price" ? var.runner_worker_docker_autoscaler_asg.spot_instance_pools : null
       }
       launch_template {
         launch_template_specification {


### PR DESCRIPTION
## Description

`spot_instance_pools` is always sent to the ASG regardless of `spot_allocation_strategy`. AWS rejects that combination for any strategy other than `lowest-price` with a `ValidationException` ("SpotInstancePools option is only available with the lowest-price allocation strategy"), making `price-capacity-optimized` ([AWS's own current recommendation](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-fleet-allocation-strategy.html)) or any non-default strategy unusable through this module. Fix: only pass `spot_instance_pools` when the strategy is `lowest-price`, `null` otherwise.

## Migrations required

No. Backward compatible: `lowest-price` (the default) is unaffected.

One caveat worth knowing: on an **existing** ASG that already has `spot_instance_pools` set in state (e.g. created under the old default), switching strategy via a plain update won't clear it. AWS provider treats this field as `Optional+Computed`, so a `null` in config carries forward the prior state value instead of unsetting it. That's a Terraform/AWS-provider behavior, not something this diff can fix. A `-replace`/taint is needed to actually reset it on an existing resource.

## Verification

Tested against a real AWS account with `spot_allocation_strategy = "price-capacity-optimized"`:
- **Before this fix**: `terraform apply` fails, confirmed via CloudTrail (`ValidationException: SpotInstancePools option is only available with the lowest-price allocation strategy`).
- **After this fix, fresh create** (`terraform apply -replace` on the ASG): succeeds. Confirmed via `describe-auto-scaling-groups` that `SpotInstancePools` is absent from the response, `SpotAllocationStrategy` is `price-capacity-optimized`.
- **After this fix, in-place update on an existing ASG**: still fails with the same `ValidationException` (see caveat above, unrelated to this diff).